### PR TITLE
cargo toml should patch downstream primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ all = "warn"
 alloy-core = { version = "0.7.7", path = "crates/core", default-features = false }
 alloy-dyn-abi = { version = "0.7.7", path = "crates/dyn-abi", default-features = false }
 alloy-json-abi = { version = "0.7.7", path = "crates/json-abi", default-features = false }
-alloy-primitives = { version = "0.7.7", path = "crates/primitives", default-features = false,  features = ["serde", "getrandom"] }
+alloy-primitives = { version = "0.7.7", path = "crates/primitives", default-features = false }
 alloy-sol-macro = { version = "0.7.7", path = "crates/sol-macro", default-features = false }
 alloy-sol-macro-input = { version = "0.7.7", path = "crates/sol-macro-input", default-features = false }
 alloy-sol-macro-expander = { version = "0.7.7", path = "crates/sol-macro-expander", default-features = false }
@@ -116,4 +116,5 @@ winnow = { version = "0.6", default-features = false, features = ["alloc"] }
 
 reth-rpc-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe43f575" }
 
-
+[patch.crates-io]
+alloy-primitives = { path = "crates/primitives" }

--- a/crates/seismic-transaction/Cargo.toml
+++ b/crates/seismic-transaction/Cargo.toml
@@ -19,7 +19,8 @@ seismic-preimages.workspace = true
 seismic-types.workspace = true
 seismic-dispatcher.workspace = true
 alloy-eips.workspace = true
-alloy-primitives = { version = "0.7.7", default-features = false, features = ["serde", "getrandom"] }
+
+alloy-primitives = { workspace = true, default-features = false, features = ["serde", "getrandom"] }
 alloy-serde.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true

--- a/crates/seismic-transaction/src/seismic_util.rs
+++ b/crates/seismic-transaction/src/seismic_util.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::{B256, U256};
-use reth_rpc_types::BlockError;
 use crate::types::SecretData;
 use seismic_preimages::{InputPreImage, PreImage};
 use seismic_types::{primitive::PrimitiveBytes, Secret};
@@ -17,11 +16,13 @@ pub enum SeismicError {
     FailedToCommitPreimage,
 }
 
+/// create a commitment from a u256 preimage
 pub fn get_commitment(value: U256) -> B256 {
     let secret = Secret::new(value);
     secret.commit_b256()
 }
 
+/// store preimages and their commitments to the secrets store
 pub fn process_secret_data(
     secret_data: Vec<SecretData>,
     input: &[u8],


### PR DESCRIPTION
also added a few small docs to get rid of build warnings