### PR TITLE
Conflicting `alloy-primitives`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,3 @@ ruint-macro = { version = "1", default-features = false }
 winnow = { version = "0.6", default-features = false, features = ["alloc"] }
 
 reth-rpc-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe43f575" }
-
-[patch.crates-io]
-alloy-primitives = { path = "crates/primitives" }

--- a/crates/seismic-transaction/Cargo.toml
+++ b/crates/seismic-transaction/Cargo.toml
@@ -20,7 +20,7 @@ seismic-types.workspace = true
 seismic-dispatcher.workspace = true
 alloy-eips.workspace = true
 
-alloy-primitives = { workspace = true, default-features = false, features = ["serde", "getrandom"] }
+alloy-primitives = { version = "0.7.7", features = ["serde", "getrandom"] }
 alloy-serde.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true

--- a/crates/seismic-transaction/src/seismic_util.rs
+++ b/crates/seismic-transaction/src/seismic_util.rs
@@ -1,5 +1,5 @@
-use alloy_primitives::{B256, U256};
 use crate::types::SecretData;
+use alloy_primitives::{B256, U256};
 use seismic_preimages::{InputPreImage, PreImage};
 use seismic_types::{primitive::PrimitiveBytes, Secret};
 
@@ -8,7 +8,7 @@ use seismic_types::{primitive::PrimitiveBytes, Secret};
 pub enum SeismicError {
     /// Error parsing preimage  
     ParsePreimageError,
-    /// Error calculating commitment 
+    /// Error calculating commitment
     CommitmentCalculationError,
     /// Error verifying commitment
     InvalidCommitmentError,
@@ -23,10 +23,7 @@ pub fn get_commitment(value: U256) -> B256 {
 }
 
 /// store preimages and their commitments to the secrets store
-pub fn process_secret_data(
-    secret_data: Vec<SecretData>,
-    input: &[u8],
-) -> Result<(), SeismicError> {
+pub fn process_secret_data(secret_data: Vec<SecretData>, input: &[u8]) -> Result<(), SeismicError> {
     let input_pre_images = create_input_pre_images(&secret_data);
 
     let preimages = parse_preimages(&input_pre_images)?;
@@ -54,14 +51,9 @@ fn create_input_pre_images(secrets: &[SecretData]) -> Vec<InputPreImage> {
 fn parse_preimages(input_pre_images: &[InputPreImage]) -> Result<Vec<PreImage>, SeismicError> {
     input_pre_images
         .iter()
-        .map(|preimage| {
-            preimage
-                .parse()
-                .map_err(|_| SeismicError::ParsePreimageError)
-        })
+        .map(|preimage| preimage.parse().map_err(|_| SeismicError::ParsePreimageError))
         .collect()
 }
-
 
 fn create_secrets(preimages: &[PreImage]) -> Vec<Secret> {
     preimages
@@ -104,7 +96,7 @@ fn extract_input_commitments(
             if end <= input.len() {
                 Ok(B256::from_slice(&input[start..end]))
             } else {
-            Err(SeismicError::CommitmentCalculationError)
+                Err(SeismicError::CommitmentCalculationError)
             }
         })
         .collect()
@@ -112,8 +104,8 @@ fn extract_input_commitments(
 
 fn verify_commitments(calculated: &[B256], input: &[B256]) -> Result<(), SeismicError> {
     if calculated != input {
-        Err(SeismicError::InvalidCommitmentError)   }
-    else {
+        Err(SeismicError::InvalidCommitmentError)
+    } else {
         Ok(())
     }
 }


### PR DESCRIPTION
Undoes the changes made in [this PR](https://github.com/SeismicSystems/seismic-alloy-core/pull/7). Although we should ideally have only one `alloy-primitives` version (our overriden version to be specific), this causes breaking changes when used with `seismic-reth` since the `alloy-primitives` and associated types, even though identical in both our fork and the original, are configured only to work with the original `alloy-primitives` crate, and hence using our version downstream causes breaking changes.