### PR TITLE
feat: Support sbytes types and clean up other stypes and tests

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [seismic]
   pull_request:
-    branches: [seismic]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/dyn-abi/src/arbitrary.rs
+++ b/crates/dyn-abi/src/arbitrary.rs
@@ -151,6 +151,8 @@ enum Choice {
     #[cfg(feature = "seismic")]
     Sbool,
     #[cfg(feature = "seismic")]
+    FixedSbytes,
+    #[cfg(feature = "seismic")]
     Sbytes,
 
     Array,
@@ -176,7 +178,9 @@ impl<'a> arbitrary::Arbitrary<'a> for DynSolType {
             #[cfg(feature = "seismic")]
             Choice::Sbool => Ok(Self::Sbool),
             #[cfg(feature = "seismic")]
-            Choice::Sbytes => Ok(Self::Sbytes(u.int_in_range(1..=32)?)),
+            Choice::FixedSbytes => Ok(Self::FixedSbytes(u.int_in_range(1..=32)?)),
+            #[cfg(feature = "seismic")]
+            Choice::Sbytes => Ok(Self::Sbytes),
             Choice::Function => Ok(Self::Function),
             Choice::FixedBytes => Ok(Self::FixedBytes(u.int_in_range(1..=32)?)),
             Choice::Bytes => Ok(Self::Bytes),
@@ -364,6 +368,8 @@ impl DynSolType {
             Just(Self::Sbool),
             any::<usize>().prop_map(|x| Self::Sint(int_size(x))),
             any::<usize>().prop_map(|x| Self::Suint(int_size(x))),
+            (1..=32usize).prop_map(Self::FixedSbytes),
+            Just(Self::Sbytes),
         ]
     }
 
@@ -454,7 +460,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             DynSolType::Sbool => u.arbitrary().map(Self::Sbool),
             #[cfg(feature = "seismic")]
-            &DynSolType::Sbytes(sz) => u.arbitrary().map(|x| Self::Sbytes(adjust_fb(x, sz), sz)),
+            &DynSolType::FixedSbytes(sz) => u.arbitrary().map(|x| Self::FixedSbytes(adjust_fb(x, sz), sz)),
+            #[cfg(feature = "seismic")]
+            DynSolType::Sbytes => u.arbitrary().map(Self::Sbytes),
         }
     }
 
@@ -506,8 +514,7 @@ impl DynSolValue {
                     .sboxed()
             }
             #[cfg(feature = "seismic")]
-            //TODO: should be a saddress?
-            &DynSolType::Saddress => any::<Address>().prop_map(Self::Address).sboxed(),
+            &DynSolType::Saddress => any::<Address>().prop_map(|x| Self::Saddress(SAddress(x))).sboxed(),
             #[cfg(feature = "seismic")]
             &DynSolType::Sint(sz) => {
                 any::<I256>().prop_map(move |x| Self::Sint(SInt(adjust_int(x, sz)), sz)).sboxed()
@@ -519,9 +526,11 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             DynSolType::Sbool => any::<bool>().prop_map(|x| Self::Sbool(Sbool(x))).sboxed(),
             #[cfg(feature = "seismic")]
-            &DynSolType::Sbytes(sz) => {
-                any::<B256>().prop_map(move |x| Self::Sbytes(adjust_fb(x, sz), sz)).sboxed()
+            &DynSolType::FixedSbytes(sz) => {
+                any::<B256>().prop_map(move |x| Self::FixedSbytes(adjust_fb(x, sz), sz)).sboxed()
             }
+            #[cfg(feature = "seismic")]
+            DynSolType::Sbytes => any::<Vec<u8>>().prop_map(Self::Sbytes).sboxed(),
         }
     }
 
@@ -559,7 +568,9 @@ impl DynSolValue {
             int_strategy::<I256>().prop_map(|(x, sz)| Self::Sint(SInt(adjust_int(x, sz)), sz)),
             int_strategy::<U256>().prop_map(|(x, sz)| Self::Suint(SUInt(adjust_uint(x, sz)), sz)),
             (any::<B256>(), 1..=32usize).prop_map(|(x, sz)| Self::FixedBytes(adjust_fb(x, sz), sz)),
+            (any::<B256>(), 1..=32usize).prop_map(|(x, sz)| Self::FixedSbytes(adjust_fb(x, sz), sz)),
             any::<Vec<u8>>().prop_map(Self::Bytes),
+            any::<Vec<u8>>().prop_map(Self::Sbytes),
             any::<String>().prop_map(Self::String),
         ]
     }

--- a/crates/dyn-abi/src/arbitrary.rs
+++ b/crates/dyn-abi/src/arbitrary.rs
@@ -20,9 +20,7 @@ use proptest::{
 };
 
 #[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SBool;
-#[cfg(feature = "seismic")]
-use alloy_primitives::aliases::{SAddress, SBytes, SFixedBytes, SInt, SUInt};
+use alloy_primitives::aliases::{SAddress, SBool, SBytes, SFixedBytes, SInt, SUInt};
 
 const DEPTH: u32 = 16;
 const DESIRED_SIZE: u32 = 64;

--- a/crates/dyn-abi/src/arbitrary.rs
+++ b/crates/dyn-abi/src/arbitrary.rs
@@ -20,9 +20,9 @@ use proptest::{
 };
 
 #[cfg(feature = "seismic")]
-use alloy_primitives::aliases::{SAddress, SInt, SUInt};
+use alloy_primitives::aliases::SBool;
 #[cfg(feature = "seismic")]
-use alloy_sol_types::sol_data::Sbool;
+use alloy_primitives::aliases::{SAddress, SBytes, SFixedBytes, SInt, SUInt};
 
 const DEPTH: u32 = 16;
 const DESIRED_SIZE: u32 = 64;
@@ -460,9 +460,11 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             DynSolType::Sbool => u.arbitrary().map(Self::Sbool),
             #[cfg(feature = "seismic")]
-            &DynSolType::FixedSbytes(sz) => u.arbitrary().map(|x| Self::FixedSbytes(adjust_fb(x, sz), sz)),
+            &DynSolType::FixedSbytes(sz) => {
+                u.arbitrary().map(|x| Self::FixedSbytes(SFixedBytes(adjust_fb(x, sz)), sz))
+            }
             #[cfg(feature = "seismic")]
-            DynSolType::Sbytes => u.arbitrary().map(Self::Sbytes),
+            DynSolType::Sbytes => u.arbitrary::<Vec<u8>>().map(|x| Self::Sbytes(SBytes(x.into()))),
         }
     }
 
@@ -514,7 +516,9 @@ impl DynSolValue {
                     .sboxed()
             }
             #[cfg(feature = "seismic")]
-            &DynSolType::Saddress => any::<Address>().prop_map(|x| Self::Saddress(SAddress(x))).sboxed(),
+            &DynSolType::Saddress => {
+                any::<Address>().prop_map(|x| Self::Saddress(SAddress(x))).sboxed()
+            }
             #[cfg(feature = "seismic")]
             &DynSolType::Sint(sz) => {
                 any::<I256>().prop_map(move |x| Self::Sint(SInt(adjust_int(x, sz)), sz)).sboxed()
@@ -524,13 +528,15 @@ impl DynSolValue {
                 any::<U256>().prop_map(move |x| Self::Suint(SUInt(adjust_uint(x, sz)), sz)).sboxed()
             }
             #[cfg(feature = "seismic")]
-            DynSolType::Sbool => any::<bool>().prop_map(|x| Self::Sbool(Sbool(x))).sboxed(),
+            DynSolType::Sbool => any::<bool>().prop_map(|x| Self::Sbool(SBool(x))).sboxed(),
             #[cfg(feature = "seismic")]
-            &DynSolType::FixedSbytes(sz) => {
-                any::<B256>().prop_map(move |x| Self::FixedSbytes(adjust_fb(x, sz), sz)).sboxed()
+            &DynSolType::FixedSbytes(sz) => any::<B256>()
+                .prop_map(move |x| Self::FixedSbytes(SFixedBytes(adjust_fb(x, sz)), sz))
+                .sboxed(),
+            #[cfg(feature = "seismic")]
+            DynSolType::Sbytes => {
+                any::<Vec<u8>>().prop_map(|x| Self::Sbytes(SBytes(x.into()))).sboxed()
             }
-            #[cfg(feature = "seismic")]
-            DynSolType::Sbytes => any::<Vec<u8>>().prop_map(Self::Sbytes).sboxed(),
         }
     }
 
@@ -560,7 +566,7 @@ impl DynSolValue {
     fn leaf() -> impl Strategy<Value = Self> {
         prop_oneof![
             any::<bool>().prop_map(Self::Bool),
-            any::<bool>().prop_map(|x| Self::Sbool(Sbool(x))),
+            any::<bool>().prop_map(|x| Self::Sbool(SBool(x))),
             any::<Address>().prop_map(Self::Address),
             int_strategy::<I256>().prop_map(|(x, sz)| Self::Int(adjust_int(x, sz), sz)),
             int_strategy::<U256>().prop_map(|(x, sz)| Self::Uint(adjust_uint(x, sz), sz)),
@@ -568,9 +574,10 @@ impl DynSolValue {
             int_strategy::<I256>().prop_map(|(x, sz)| Self::Sint(SInt(adjust_int(x, sz)), sz)),
             int_strategy::<U256>().prop_map(|(x, sz)| Self::Suint(SUInt(adjust_uint(x, sz)), sz)),
             (any::<B256>(), 1..=32usize).prop_map(|(x, sz)| Self::FixedBytes(adjust_fb(x, sz), sz)),
-            (any::<B256>(), 1..=32usize).prop_map(|(x, sz)| Self::FixedSbytes(adjust_fb(x, sz), sz)),
+            (any::<B256>(), 1..=32usize)
+                .prop_map(|(x, sz)| Self::FixedSbytes(SFixedBytes(adjust_fb(x, sz)), sz)),
             any::<Vec<u8>>().prop_map(Self::Bytes),
-            any::<Vec<u8>>().prop_map(Self::Sbytes),
+            any::<Vec<u8>>().prop_map(|x| Self::Sbytes(SBytes(x.into()))),
             any::<String>().prop_map(Self::String),
         ]
     }

--- a/crates/dyn-abi/src/coerce.rs
+++ b/crates/dyn-abi/src/coerce.rs
@@ -139,9 +139,11 @@ impl<'i> Parser<Input<'i>, DynSolValue, ErrMode<ContextError>> for ValueParser<'
             #[cfg(feature = "seismic")]
             DynSolType::Sbool => bool(input).map(|x| DynSolValue::Sbool(Sbool(x))),
             #[cfg(feature = "seismic")]
-            DynSolType::Sbytes(size) => {
-                fixed_bytes(*size).parse_next(input).map(|x| DynSolValue::Sbytes(x, *size))
+            DynSolType::FixedSbytes(size) => {
+                fixed_bytes(*size).parse_next(input).map(|x| DynSolValue::FixedSbytes(x, *size))
             }
+            #[cfg(feature = "seismic")]
+            DynSolType::Sbytes => bytes(input).map(DynSolValue::Sbytes),
         })
         .parse_next(input)
     }

--- a/crates/dyn-abi/src/coerce.rs
+++ b/crates/dyn-abi/src/coerce.rs
@@ -20,9 +20,9 @@ use winnow::{
 };
 
 #[cfg(feature = "seismic")]
-use alloy_primitives::aliases::{SAddress, SInt, SUInt};
+use alloy_primitives::aliases::SBool;
 #[cfg(feature = "seismic")]
-use alloy_sol_types::Sbool;
+use alloy_primitives::aliases::{SAddress, SBytes, SFixedBytes, SInt, SUInt};
 
 impl DynSolType {
     /// Coerces a string into a [`DynSolValue`] via this type.
@@ -137,13 +137,13 @@ impl<'i> Parser<Input<'i>, DynSolValue, ErrMode<ContextError>> for ValueParser<'
                 uint(*size).parse_next(input).map(|x| DynSolValue::Suint(SUInt(x), *size))
             }
             #[cfg(feature = "seismic")]
-            DynSolType::Sbool => bool(input).map(|x| DynSolValue::Sbool(Sbool(x))),
+            DynSolType::Sbool => bool(input).map(|x| DynSolValue::Sbool(SBool(x))),
             #[cfg(feature = "seismic")]
-            DynSolType::FixedSbytes(size) => {
-                fixed_bytes(*size).parse_next(input).map(|x| DynSolValue::FixedSbytes(x, *size))
-            }
+            DynSolType::FixedSbytes(size) => fixed_bytes(*size)
+                .parse_next(input)
+                .map(|x| DynSolValue::FixedSbytes(SFixedBytes(x), *size)),
             #[cfg(feature = "seismic")]
-            DynSolType::Sbytes => bytes(input).map(DynSolValue::Sbytes),
+            DynSolType::Sbytes => bytes(input).map(|x| DynSolValue::Sbytes(SBytes(x.into()))),
         })
         .parse_next(input)
     }

--- a/crates/dyn-abi/src/coerce.rs
+++ b/crates/dyn-abi/src/coerce.rs
@@ -20,9 +20,7 @@ use winnow::{
 };
 
 #[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SBool;
-#[cfg(feature = "seismic")]
-use alloy_primitives::aliases::{SAddress, SBytes, SFixedBytes, SInt, SUInt};
+use alloy_primitives::aliases::{SAddress, SBool, SBytes, SFixedBytes, SInt, SUInt};
 
 impl DynSolType {
     /// Coerces a string into a [`DynSolValue`] via this type.

--- a/crates/dyn-abi/src/dynamic/ty.rs
+++ b/crates/dyn-abi/src/dynamic/ty.rs
@@ -489,29 +489,19 @@ impl DynSolType {
                 out.push(']');
             }
             #[cfg(feature = "seismic")]
-            Self::Saddress => out.push_str("saddress"),
-            #[cfg(feature = "seismic")]
-            Self::Sint(size) => {
-                out.push_str("sint");
-                out.push_str(itoa::Buffer::new().format(*size));
-            }
-            #[cfg(feature = "seismic")]
-            Self::Suint(size) => {
-                out.push_str("suint");
-                out.push_str(itoa::Buffer::new().format(*size));
-            }
-            #[cfg(feature = "seismic")]
-            Self::Sbool => {
+            Self::Saddress | Self::Sbool | Self::Sbytes => {
                 out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
+            }
+            #[cfg(feature = "seismic")]
+            Self::Sint(size) | Self::Suint(size) => {
+                let prefix = if matches!(self, Self::Sint(_)) { "sint" } else { "suint" };
+                out.push_str(prefix);
+                out.push_str(itoa::Buffer::new().format(*size));
             }
             #[cfg(feature = "seismic")]
             Self::FixedSbytes(size) => {
                 out.push_str("sbytes");
                 out.push_str(itoa::Buffer::new().format(*size));
-            }
-            #[cfg(feature = "seismic")]
-            Self::Sbytes => {
-                out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
             }
         }
     }

--- a/crates/dyn-abi/src/dynamic/ty.rs
+++ b/crates/dyn-abi/src/dynamic/ty.rs
@@ -188,7 +188,12 @@ impl DynSolType {
             | Self::Bytes
             | Self::String => 0,
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::FixedSbytes(_) | Self::Sbytes => 0,
+            Self::Saddress
+            | Self::Sint(_)
+            | Self::Suint(_)
+            | Self::Sbool
+            | Self::FixedSbytes(_)
+            | Self::Sbytes => 0,
             Self::Array(contents) | Self::FixedArray(contents, _) => 1 + contents.nesting_depth(),
             as_tuple!(Self tuple) => 1 + tuple.iter().map(Self::nesting_depth).max().unwrap_or(0),
         }
@@ -392,12 +397,15 @@ impl DynSolType {
             }
 
             #[cfg(feature = "seismic")]
-            (Self::FixedSbytes(size), DynToken::Word(word)) => {
-                Ok(DynSolValue::FixedSbytes(sol_data::FixedSbytes::<32>::detokenize(word.into()), *size))
-            }
+            (Self::FixedSbytes(size), DynToken::Word(word)) => Ok(DynSolValue::FixedSbytes(
+                sol_data::FixedSbytes::<32>::detokenize(word.into()),
+                *size,
+            )),
 
             #[cfg(feature = "seismic")]
-            (Self::Sbytes, DynToken::PackedSeq(buf)) => Ok(DynSolValue::Sbytes(buf.to_vec())),
+            (Self::Sbytes, DynToken::PackedSeq(buf)) => {
+                Ok(DynSolValue::Sbytes(alloy_primitives::aliases::SBytes(buf.to_vec().into())))
+            }
 
             _ => Err(crate::Error::custom("mismatched types on dynamic detokenization")),
         }
@@ -591,9 +599,11 @@ impl DynSolType {
                 DynToken::FixedSeq(tokens.into(), tuple.len())
             }
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Suint(_) | Self::Sint(_) | Self::Sbool | Self::FixedSbytes(_) => {
-                DynToken::Word(Word::ZERO)
-            }
+            Self::Saddress
+            | Self::Suint(_)
+            | Self::Sint(_)
+            | Self::Sbool
+            | Self::FixedSbytes(_) => DynToken::Word(Word::ZERO),
             #[cfg(feature = "seismic")]
             Self::Sbytes => DynToken::PackedSeq(&[]),
         })
@@ -609,9 +619,11 @@ impl DynSolType {
             | Self::Int(_)
             | Self::Uint(_) => self.detokenize(DynToken::Word(topic)).unwrap(),
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::FixedSbytes(_) => {
-                self.detokenize(DynToken::Word(topic)).unwrap()
-            }
+            Self::Saddress
+            | Self::Sint(_)
+            | Self::Suint(_)
+            | Self::Sbool
+            | Self::FixedSbytes(_) => self.detokenize(DynToken::Word(topic)).unwrap(),
             _ => DynSolValue::FixedBytes(topic, 32),
         }
     }
@@ -677,9 +689,11 @@ impl DynSolType {
             Self::Tuple(tuple) => tuple.iter().any(Self::is_dynamic),
             Self::FixedArray(inner, _) => inner.is_dynamic(),
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(..) | Self::Suint(..) | Self::Sbool | Self::FixedSbytes(..) => {
-                false
-            }
+            Self::Saddress
+            | Self::Sint(..)
+            | Self::Suint(..)
+            | Self::Sbool
+            | Self::FixedSbytes(..) => false,
             #[cfg(feature = "seismic")]
             Self::Sbytes => true,
             #[cfg(feature = "eip712")]

--- a/crates/dyn-abi/src/dynamic/ty.rs
+++ b/crates/dyn-abi/src/dynamic/ty.rs
@@ -117,8 +117,11 @@ pub enum DynSolType {
     /// Boolean.
     Sbool,
     #[cfg(feature = "seismic")]
-    /// Seismic shielded fixed-size bytes
-    Sbytes(usize),
+    /// Seismic shielded fixed-size bytes - `sbytesN`
+    FixedSbytes(usize),
+    #[cfg(feature = "seismic")]
+    /// Seismic shielded dynamic bytes - `sbytes`
+    Sbytes,
 
     /// Signed Integer.
     /// User-defined struct.
@@ -185,7 +188,7 @@ impl DynSolType {
             | Self::Bytes
             | Self::String => 0,
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::Sbytes(_) => 0,
+            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::FixedSbytes(_) | Self::Sbytes => 0,
             Self::Array(contents) | Self::FixedArray(contents, _) => 1 + contents.nesting_depth(),
             as_tuple!(Self tuple) => 1 + tuple.iter().map(Self::nesting_depth).max().unwrap_or(0),
         }
@@ -287,7 +290,9 @@ impl DynSolType {
             #[cfg(feature = "seismic")]
             Self::Sbool => matches!(value, DynSolValue::Sbool(_)),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(size) => matches!(value, DynSolValue::Sbytes(_, s) if s == size),
+            Self::FixedSbytes(size) => matches!(value, DynSolValue::FixedSbytes(_, s) if s == size),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes => matches!(value, DynSolValue::Sbytes(_)),
         }
     }
 
@@ -387,9 +392,12 @@ impl DynSolType {
             }
 
             #[cfg(feature = "seismic")]
-            (Self::Sbytes(size), DynToken::Word(word)) => {
-                Ok(DynSolValue::Sbytes(sol_data::Sbytes::<32>::detokenize(word.into()), *size))
+            (Self::FixedSbytes(size), DynToken::Word(word)) => {
+                Ok(DynSolValue::FixedSbytes(sol_data::FixedSbytes::<32>::detokenize(word.into()), *size))
             }
+
+            #[cfg(feature = "seismic")]
+            (Self::Sbytes, DynToken::PackedSeq(buf)) => Ok(DynSolValue::Sbytes(buf.to_vec())),
 
             _ => Err(crate::Error::custom("mismatched types on dynamic detokenization")),
         }
@@ -425,6 +433,8 @@ impl DynSolType {
             Self::Saddress => Some("saddress"),
             #[cfg(feature = "seismic")]
             Self::Sbool => Some("sbool"),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes => Some("sbytes"),
             _ => None,
         }
     }
@@ -487,9 +497,13 @@ impl DynSolType {
                 out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
             }
             #[cfg(feature = "seismic")]
-            Self::Sbytes(size) => {
+            Self::FixedSbytes(size) => {
                 out.push_str("sbytes");
                 out.push_str(itoa::Buffer::new().format(*size));
+            }
+            #[cfg(feature = "seismic")]
+            Self::Sbytes => {
+                out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
             }
         }
     }
@@ -518,7 +532,7 @@ impl DynSolType {
             as_tuple!(Self tuple) // sum(tuple) + len(tuple) + 2
             => tuple.iter().map(Self::sol_type_name_capacity).sum::<usize>() + 8,
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::Sbytes(_) => 8,
+            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::FixedSbytes(_) | Self::Sbytes => 8,
         }
     }
 
@@ -577,9 +591,11 @@ impl DynSolType {
                 DynToken::FixedSeq(tokens.into(), tuple.len())
             }
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Suint(_) | Self::Sint(_) | Self::Sbool | Self::Sbytes(_) => {
+            Self::Saddress | Self::Suint(_) | Self::Sint(_) | Self::Sbool | Self::FixedSbytes(_) => {
                 DynToken::Word(Word::ZERO)
             }
+            #[cfg(feature = "seismic")]
+            Self::Sbytes => DynToken::PackedSeq(&[]),
         })
     }
 
@@ -593,7 +609,7 @@ impl DynSolType {
             | Self::Int(_)
             | Self::Uint(_) => self.detokenize(DynToken::Word(topic)).unwrap(),
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::Sbytes(_) => {
+            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::FixedSbytes(_) => {
                 self.detokenize(DynToken::Word(topic)).unwrap()
             }
             _ => DynSolValue::FixedBytes(topic, 32),
@@ -661,9 +677,11 @@ impl DynSolType {
             Self::Tuple(tuple) => tuple.iter().any(Self::is_dynamic),
             Self::FixedArray(inner, _) => inner.is_dynamic(),
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(..) | Self::Suint(..) | Self::Sbool | Self::Sbytes(..) => {
+            Self::Saddress | Self::Sint(..) | Self::Suint(..) | Self::Sbool | Self::FixedSbytes(..) => {
                 false
             }
+            #[cfg(feature = "seismic")]
+            Self::Sbytes => true,
             #[cfg(feature = "eip712")]
             Self::CustomStruct { tuple, .. } => tuple.iter().any(Self::is_dynamic),
         }
@@ -690,7 +708,9 @@ impl DynSolType {
             #[cfg(feature = "eip712")]
             Self::CustomStruct { tuple, ..} => tuple.iter().map(|ty| ty.minimum_words()).sum(),
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::Sbytes(_) => 1,
+            Self::Saddress | Self::Sint(_) | Self::Suint(_) | Self::Sbool | Self::FixedSbytes(_) => 1,
+            #[cfg(feature = "seismic")]
+            Self::Sbytes => 2,
         }
     }
 

--- a/crates/dyn-abi/src/dynamic/value.rs
+++ b/crates/dyn-abi/src/dynamic/value.rs
@@ -105,7 +105,10 @@ pub enum DynSolValue {
     Sbool(Sbool),
     #[cfg(feature = "seismic")]
     /// A seismic fixed-length byte array. The second parameter is the number of bytes.
-    Sbytes(Word, usize),
+    FixedSbytes(Word, usize),
+    #[cfg(feature = "seismic")]
+    /// A seismic dynamic byte array.
+    Sbytes(Vec<u8>),
 
     /// A named struct, treated as a tuple with a name parameter.
     #[cfg(feature = "eip712")]
@@ -259,7 +262,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(_) => DynSolType::Sbool,
             #[cfg(feature = "seismic")]
-            Self::Sbytes(_, size) => DynSolType::Sbytes(*size),
+            Self::FixedSbytes(_, size) => DynSolType::FixedSbytes(*size),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => DynSolType::Sbytes,
         };
         Some(ty)
     }
@@ -277,6 +282,8 @@ impl DynSolValue {
             Self::Sbool(_) => Some("sbool"),
             #[cfg(feature = "seismic")]
             Self::Saddress(_) => Some("saddress"),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => Some("sbytes"),
             _ => None,
         }
     }
@@ -347,9 +354,13 @@ impl DynSolValue {
                 out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
             }
             #[cfg(feature = "seismic")]
-            Self::Sbytes(_, size) => {
+            Self::FixedSbytes(_, size) => {
                 out.push_str("sbytes");
                 out.push_str(itoa::Buffer::new().format(*size));
+            }
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => {
+                out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
             }
         }
     }
@@ -385,7 +396,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(_) => Some(8),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(_, _) => Some(8),
+            Self::FixedSbytes(_, _) => Some(8),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => Some(8),
         }
     }
 
@@ -415,7 +428,7 @@ impl DynSolValue {
                     | Self::Sint(..)
                     | Self::Suint(..)
                     | Self::Sbool(_)
-                    | Self::Sbytes(..)
+                    | Self::FixedSbytes(..)
             );
             if is_sword {
                 return true;
@@ -450,7 +463,7 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(b) => Some(Word::with_last_byte(b.0.into())),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(w, _) => Some(w),
+            Self::FixedSbytes(w, _) => Some(w),
             _ => None,
         }
     }
@@ -492,7 +505,7 @@ impl DynSolValue {
         match self {
             Self::FixedBytes(w, size) => Some((w.as_slice(), *size)),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(w, size) => Some((w.as_slice(), *size)),
+            Self::FixedSbytes(w, size) => Some((w.as_slice(), *size)),
             _ => None,
         }
     }
@@ -618,6 +631,8 @@ impl DynSolValue {
         match self {
             Self::String(s) => Some(s.as_bytes()),
             Self::Bytes(b) => Some(b),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(b) => Some(b),
             _ => None,
         }
     }
@@ -639,7 +654,9 @@ impl DynSolValue {
             | Self::Sint(_, _)
             | Self::Suint(_, _)
             | Self::Sbool(_)
-            | Self::Sbytes(_, _) => false,
+            | Self::FixedSbytes(_, _) => false,
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => true,
         }
     }
 
@@ -724,7 +741,9 @@ impl DynSolValue {
             | Self::Sint(_, _)
             | Self::Suint(_, _)
             | Self::Sbool(_)
-            | Self::Sbytes(_, _) => 0,
+            | Self::FixedSbytes(_, _) => 0,
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(b) => 1 + words_for_len(b.len()),
         }
     }
 
@@ -762,7 +781,9 @@ impl DynSolValue {
             | Self::Sint(_, _)
             | Self::Suint(_, _)
             | Self::Sbool(_)
-            | Self::Sbytes(_, _) => enc.append_word(unsafe { self.as_word().unwrap_unchecked() }),
+            | Self::FixedSbytes(_, _) => enc.append_word(unsafe { self.as_word().unwrap_unchecked() }),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => enc.append_indirection(),
         }
     }
 
@@ -795,7 +816,9 @@ impl DynSolValue {
             | Self::Sint(_, _)
             | Self::Suint(_, _)
             | Self::Sbool(_)
-            | Self::Sbytes(_, _) => {}
+            | Self::FixedSbytes(_, _) => {}
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(bytes) => enc.append_packed_seq(bytes),
         }
     }
 
@@ -866,7 +889,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(b) => buf.push(b.0.into()),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(w, size) => buf.extend_from_slice(&w[..(*size).min(32)]),
+            Self::FixedSbytes(w, size) => buf.extend_from_slice(&w[..(*size).min(32)]),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(bytes) => buf.extend_from_slice(bytes),
         }
     }
 
@@ -894,7 +919,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(_) => 1,
             #[cfg(feature = "seismic")]
-            Self::Sbytes(_, size) => (*size).min(32),
+            Self::FixedSbytes(_, size) => (*size).min(32),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(b) => b.len(),
         }
     }
 
@@ -920,7 +947,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(b) => Word::with_last_byte(b.0.into()).into(),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(buf, _) => (*buf).into(),
+            Self::FixedSbytes(buf, _) => (*buf).into(),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(buf) => DynToken::PackedSeq(buf),
         }
     }
 

--- a/crates/dyn-abi/src/dynamic/value.rs
+++ b/crates/dyn-abi/src/dynamic/value.rs
@@ -1,13 +1,15 @@
 use super::ty::as_tuple;
 use crate::{DynSolType, DynToken, Word};
 use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "seismic")]
+use alloy_primitives::aliases::SBool;
 use alloy_primitives::{Address, Function, I256, U256};
 #[cfg(feature = "seismic")]
 use alloy_primitives::{
     SAddress, SI256, SU256,
-    aliases::{SInt, SUInt},
+    aliases::{SBytes, SFixedBytes, SInt, SUInt},
 };
-use alloy_sol_types::{abi::Encoder, sol_data::Sbool, utils::words_for_len};
+use alloy_sol_types::{abi::Encoder, utils::words_for_len};
 
 #[cfg(feature = "eip712")]
 macro_rules! as_fixed_seq {
@@ -102,13 +104,13 @@ pub enum DynSolValue {
     Suint(SU256, usize),
     #[cfg(feature = "seismic")]
     /// A seismic bool.
-    Sbool(Sbool),
+    Sbool(SBool),
     #[cfg(feature = "seismic")]
     /// A seismic fixed-length byte array. The second parameter is the number of bytes.
-    FixedSbytes(Word, usize),
+    FixedSbytes(SFixedBytes<32>, usize),
     #[cfg(feature = "seismic")]
     /// A seismic dynamic byte array.
-    Sbytes(Vec<u8>),
+    Sbytes(SBytes),
 
     /// A named struct, treated as a tuple with a name parameter.
     #[cfg(feature = "eip712")]
@@ -463,7 +465,7 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(b) => Some(Word::with_last_byte(b.0.into())),
             #[cfg(feature = "seismic")]
-            Self::FixedSbytes(w, _) => Some(w),
+            Self::FixedSbytes(w, _) => Some(w.0),
             _ => None,
         }
     }
@@ -505,7 +507,7 @@ impl DynSolValue {
         match self {
             Self::FixedBytes(w, size) => Some((w.as_slice(), *size)),
             #[cfg(feature = "seismic")]
-            Self::FixedSbytes(w, size) => Some((w.as_slice(), *size)),
+            Self::FixedSbytes(w, size) => Some((w.0.as_slice(), *size)),
             _ => None,
         }
     }
@@ -632,7 +634,7 @@ impl DynSolValue {
             Self::String(s) => Some(s.as_bytes()),
             Self::Bytes(b) => Some(b),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(b) => Some(b),
+            Self::Sbytes(b) => Some(b.0.as_ref()),
             _ => None,
         }
     }
@@ -743,7 +745,7 @@ impl DynSolValue {
             | Self::Sbool(_)
             | Self::FixedSbytes(_, _) => 0,
             #[cfg(feature = "seismic")]
-            Self::Sbytes(b) => 1 + words_for_len(b.len()),
+            Self::Sbytes(b) => 1 + words_for_len(b.0.len()),
         }
     }
 
@@ -781,7 +783,9 @@ impl DynSolValue {
             | Self::Sint(_, _)
             | Self::Suint(_, _)
             | Self::Sbool(_)
-            | Self::FixedSbytes(_, _) => enc.append_word(unsafe { self.as_word().unwrap_unchecked() }),
+            | Self::FixedSbytes(_, _) => {
+                enc.append_word(unsafe { self.as_word().unwrap_unchecked() })
+            }
             #[cfg(feature = "seismic")]
             Self::Sbytes(_) => enc.append_indirection(),
         }
@@ -818,7 +822,7 @@ impl DynSolValue {
             | Self::Sbool(_)
             | Self::FixedSbytes(_, _) => {}
             #[cfg(feature = "seismic")]
-            Self::Sbytes(bytes) => enc.append_packed_seq(bytes),
+            Self::Sbytes(bytes) => enc.append_packed_seq(bytes.0.as_ref()),
         }
     }
 
@@ -889,9 +893,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(b) => buf.push(b.0.into()),
             #[cfg(feature = "seismic")]
-            Self::FixedSbytes(w, size) => buf.extend_from_slice(&w[..(*size).min(32)]),
+            Self::FixedSbytes(w, size) => buf.extend_from_slice(&w.0[..(*size).min(32)]),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(bytes) => buf.extend_from_slice(bytes),
+            Self::Sbytes(bytes) => buf.extend_from_slice(bytes.0.as_ref()),
         }
     }
 
@@ -921,7 +925,7 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::FixedSbytes(_, size) => (*size).min(32),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(b) => b.len(),
+            Self::Sbytes(b) => b.0.len(),
         }
     }
 
@@ -947,9 +951,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Sbool(b) => Word::with_last_byte(b.0.into()).into(),
             #[cfg(feature = "seismic")]
-            Self::FixedSbytes(buf, _) => (*buf).into(),
+            Self::FixedSbytes(buf, _) => (buf.0).into(),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(buf) => DynToken::PackedSeq(buf),
+            Self::Sbytes(buf) => DynToken::PackedSeq(buf.0.as_ref()),
         }
     }
 

--- a/crates/dyn-abi/src/dynamic/value.rs
+++ b/crates/dyn-abi/src/dynamic/value.rs
@@ -1,13 +1,11 @@
 use super::ty::as_tuple;
 use crate::{DynSolType, DynToken, Word};
 use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
-#[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SBool;
 use alloy_primitives::{Address, Function, I256, U256};
 #[cfg(feature = "seismic")]
 use alloy_primitives::{
     SAddress, SI256, SU256,
-    aliases::{SBytes, SFixedBytes, SInt, SUInt},
+    aliases::{SBool, SBytes, SFixedBytes, SInt, SUInt},
 };
 use alloy_sol_types::{abi::Encoder, utils::words_for_len};
 
@@ -342,27 +340,19 @@ impl DynSolValue {
                 out.push(')');
             }
             #[cfg(feature = "seismic")]
-            Self::Sint(_, size) => {
-                out.push_str("sint");
-                out.push_str(itoa::Buffer::new().format(*size));
-            }
-            #[cfg(feature = "seismic")]
-            Self::Suint(_, size) => {
-                out.push_str("suint");
-                out.push_str(itoa::Buffer::new().format(*size));
-            }
-            #[cfg(feature = "seismic")]
-            Self::Sbool(_) | Self::Saddress(_) => {
+            Self::Sbool(_) | Self::Saddress(_) | Self::Sbytes(_) => {
                 out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
             }
             #[cfg(feature = "seismic")]
-            Self::FixedSbytes(_, size) => {
-                out.push_str("sbytes");
+            Self::Sint(_, size) | Self::Suint(_, size) | Self::FixedSbytes(_, size) => {
+                let prefix = match self {
+                    Self::Sint(..) => "sint",
+                    Self::Suint(..) => "suint",
+                    Self::FixedSbytes(..) => "sbytes",
+                    _ => unreachable!(),
+                };
+                out.push_str(prefix);
                 out.push_str(itoa::Buffer::new().format(*size));
-            }
-            #[cfg(feature = "seismic")]
-            Self::Sbytes(_) => {
-                out.push_str(unsafe { self.sol_type_name_simple().unwrap_unchecked() });
             }
         }
     }
@@ -390,17 +380,12 @@ impl DynSolValue {
                 tuple.iter().map(Self::sol_type_name_capacity).sum::<Option<usize>>().map(|x| x + 8)
             }
             #[cfg(feature = "seismic")]
-            Self::Saddress(_) => Some(8),
-            #[cfg(feature = "seismic")]
-            Self::Sint(_, _) => Some(8),
-            #[cfg(feature = "seismic")]
-            Self::Suint(_, _) => Some(8),
-            #[cfg(feature = "seismic")]
-            Self::Sbool(_) => Some(8),
-            #[cfg(feature = "seismic")]
-            Self::FixedSbytes(_, _) => Some(8),
-            #[cfg(feature = "seismic")]
-            Self::Sbytes(_) => Some(8),
+            Self::Saddress(_)
+            | Self::Sint(..)
+            | Self::Suint(..)
+            | Self::Sbool(_)
+            | Self::FixedSbytes(..)
+            | Self::Sbytes(_) => Some(8),
         }
     }
 
@@ -917,11 +902,9 @@ impl DynSolValue {
             #[cfg(feature = "seismic")]
             Self::Saddress(_) => 20,
             #[cfg(feature = "seismic")]
-            Self::Sint(SInt(_), size) => (size / 8).min(32),
-            #[cfg(feature = "seismic")]
-            Self::Suint(SUInt(_), size) => (size / 8).min(32),
-            #[cfg(feature = "seismic")]
             Self::Sbool(_) => 1,
+            #[cfg(feature = "seismic")]
+            Self::Sint(_, size) | Self::Suint(_, size) => (size / 8).min(32),
             #[cfg(feature = "seismic")]
             Self::FixedSbytes(_, size) => (*size).min(32),
             #[cfg(feature = "seismic")]

--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -41,7 +41,7 @@ impl DynSolType {
                 custom_struct(name, prop_names, tuple, value)
             }
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Suint(_) | Self::Sint(_) | Self::Sbool | Self::Sbytes(_) => {
+            Self::Saddress | Self::Suint(_) | Self::Sint(_) | Self::Sbool | Self::FixedSbytes(_) | Self::Sbytes => {
                 self.coerce_json_simple(value).ok_or_else(err)
             }
         }
@@ -66,7 +66,9 @@ impl DynSolType {
             #[cfg(feature = "seismic")]
             Self::Sbool => bool(value).map(|x| DynSolValue::Sbool(Sbool(x))),
             #[cfg(feature = "seismic")]
-            Self::Sbytes(n) => fixed_bytes(*n, value).map(|x| DynSolValue::Sbytes(x, *n)),
+            Self::FixedSbytes(n) => fixed_bytes(*n, value).map(|x| DynSolValue::FixedSbytes(x, *n)),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes => bytes(value).map(DynSolValue::Sbytes),
             _ => unreachable!(),
         }
     }

--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -6,10 +6,10 @@ use alloc::{
 use alloy_primitives::{Address, Function, I256, U256, hex};
 
 #[cfg(feature = "seismic")]
-use alloy_primitives::aliases::{SAddress, SInt, SUInt};
+use alloy_primitives::aliases::{SAddress, SBytes, SFixedBytes, SInt, SUInt};
 
 #[cfg(feature = "seismic")]
-use alloy_sol_types::Sbool;
+use alloy_primitives::aliases::SBool;
 
 impl DynSolType {
     /// Coerce a [`serde_json::Value`] to a [`DynSolValue`] via this type.
@@ -41,9 +41,12 @@ impl DynSolType {
                 custom_struct(name, prop_names, tuple, value)
             }
             #[cfg(feature = "seismic")]
-            Self::Saddress | Self::Suint(_) | Self::Sint(_) | Self::Sbool | Self::FixedSbytes(_) | Self::Sbytes => {
-                self.coerce_json_simple(value).ok_or_else(err)
-            }
+            Self::Saddress
+            | Self::Suint(_)
+            | Self::Sint(_)
+            | Self::Sbool
+            | Self::FixedSbytes(_)
+            | Self::Sbytes => self.coerce_json_simple(value).ok_or_else(err),
         }
     }
 
@@ -64,11 +67,13 @@ impl DynSolType {
             #[cfg(feature = "seismic")]
             Self::Suint(n) => uint(*n, value).map(|x| DynSolValue::Suint(SUInt(x), *n)),
             #[cfg(feature = "seismic")]
-            Self::Sbool => bool(value).map(|x| DynSolValue::Sbool(Sbool(x))),
+            Self::Sbool => bool(value).map(|x| DynSolValue::Sbool(SBool(x))),
             #[cfg(feature = "seismic")]
-            Self::FixedSbytes(n) => fixed_bytes(*n, value).map(|x| DynSolValue::FixedSbytes(x, *n)),
+            Self::FixedSbytes(n) => {
+                fixed_bytes(*n, value).map(|x| DynSolValue::FixedSbytes(SFixedBytes(x), *n))
+            }
             #[cfg(feature = "seismic")]
-            Self::Sbytes => bytes(value).map(DynSolValue::Sbytes),
+            Self::Sbytes => bytes(value).map(|x| DynSolValue::Sbytes(SBytes(x.into()))),
             _ => unreachable!(),
         }
     }

--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -6,10 +6,7 @@ use alloc::{
 use alloy_primitives::{Address, Function, I256, U256, hex};
 
 #[cfg(feature = "seismic")]
-use alloy_primitives::aliases::{SAddress, SBytes, SFixedBytes, SInt, SUInt};
-
-#[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SBool;
+use alloy_primitives::aliases::{SAddress, SBool, SBytes, SFixedBytes, SInt, SUInt};
 
 impl DynSolType {
     /// Coerce a [`serde_json::Value`] to a [`DynSolValue`] via this type.

--- a/crates/dyn-abi/src/specifier.rs
+++ b/crates/dyn-abi/src/specifier.rs
@@ -68,6 +68,8 @@ impl Specifier<DynSolType> for RootType<'_> {
             "sint" => Ok(DynSolType::Sint(256)),
             #[cfg(feature = "seismic")]
             "suint" => Ok(DynSolType::Suint(256)),
+            #[cfg(feature = "seismic")]
+            "sbytes" => Ok(DynSolType::Sbytes),
 
             name => {
                 if let Some(sz) = name.strip_prefix("bytes") {
@@ -83,7 +85,7 @@ impl Specifier<DynSolType> for RootType<'_> {
                 if let Some(sz) = name.strip_prefix("sbytes") {
                     if let Ok(sz) = sz.parse() {
                         if sz != 0 && sz <= 32 {
-                            return Ok(DynSolType::Sbytes(sz));
+                            return Ok(DynSolType::FixedSbytes(sz));
                         }
                     }
                     return Err(parser::Error::invalid_size(name).into());

--- a/crates/primitives/src/aliases.rs
+++ b/crates/primitives/src/aliases.rs
@@ -63,13 +63,13 @@ int_aliases! {
 }
 
 #[cfg(feature = "seismic")]
-#[doc = "seismic unsigned integer type][Sint], where the preimage is a signed integer"]
+#[doc = "Seismic shielded unsigned integer type, where the preimage is an unsigned integer."]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub struct SUInt<const BITS: usize, const LIMBS: usize>(pub Uint<BITS, LIMBS>);
 
 #[cfg(feature = "seismic")]
-#[doc = "seismic unsigned integer type][Suint], where the preimage is an unsigned integer"]
+#[doc = "Seismic shielded signed integer type, where the preimage is a signed integer."]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub struct SInt<const BITS: usize, const LIMBS: usize>(pub Signed<BITS, LIMBS>);
@@ -174,7 +174,7 @@ sint_aliases! {
    SU128, SI128<128, 2>,
 
    SU136, SI136<136, 3>,
-   SU144, SI144<144, 3  >,
+   SU144, SI144<144, 3>,
    SU152, SI152<152, 3>,
    SU160, SI160<160, 3>,
    SU168, SI168<168, 3>,

--- a/crates/primitives/src/aliases.rs
+++ b/crates/primitives/src/aliases.rs
@@ -64,32 +64,14 @@ int_aliases! {
 
 #[cfg(feature = "seismic")]
 #[doc = "seismic unsigned integer type][Sint], where the preimage is a signed integer"]
-#[derive(
-    // Standard derives
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Debug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub struct SUInt<const BITS: usize, const LIMBS: usize>(pub Uint<BITS, LIMBS>);
 
 #[cfg(feature = "seismic")]
 #[doc = "seismic unsigned integer type][Suint], where the preimage is an unsigned integer"]
-#[derive(
-    // Standard derives
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Debug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub struct SInt<const BITS: usize, const LIMBS: usize>(pub Signed<BITS, LIMBS>);
 
 #[cfg(feature = "seismic")]
@@ -104,31 +86,70 @@ macro_rules! sint_aliases {
 }
 
 #[cfg(feature = "seismic")]
-#[derive(Copy, Clone, Debug, PartialEq)]
-/// Seismic-shielded address type. Preimage is an address
+/// Seismic-shielded address type. Preimage is an address.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub struct SAddress(pub crate::Address);
 
-#[cfg(all(feature = "seismic", feature = "arbitrary"))]
-impl arbitrary::Arbitrary<'_> for SAddress {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let arbitrary_addr = u.arbitrary::<crate::Address>()?;
-        Ok(SAddress(arbitrary_addr))
+#[cfg(feature = "seismic")]
+/// Seismic-shielded boolean type. Preimage is a bool.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
+pub struct SBool(pub bool);
+
+#[cfg(feature = "seismic")]
+/// Seismic-shielded fixed byte array type. Preimage is a fixed byte array.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
+pub struct SFixedBytes<const N: usize>(pub FixedBytes<N>);
+
+#[cfg(feature = "seismic")]
+/// Seismic-shielded dynamic byte array type. Preimage is a byte array.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct SBytes(pub crate::Bytes);
+
+#[cfg(feature = "seismic")]
+impl AsRef<[u8]> for SBytes {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+#[cfg(feature = "seismic")]
+impl SBytes {
+    /// Returns the length of the byte array.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the byte array is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[cfg(feature = "seismic")]
+impl From<alloc::vec::Vec<u8>> for SBytes {
+    fn from(v: alloc::vec::Vec<u8>) -> Self {
+        SBytes(v.into())
     }
 }
 
 #[cfg(all(feature = "seismic", feature = "arbitrary"))]
-impl<const BITS: usize, const LIMBS: usize> arbitrary::Arbitrary<'_> for SUInt<BITS, LIMBS> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let arbitrary_uint = u.arbitrary::<Uint<BITS, LIMBS>>()?;
-        Ok(SUInt(arbitrary_uint))
+impl<'a> arbitrary::Arbitrary<'a> for SBytes {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        u.arbitrary::<crate::Bytes>().map(SBytes)
     }
 }
 
 #[cfg(all(feature = "seismic", feature = "arbitrary"))]
-impl<const BITS: usize, const LIMBS: usize> arbitrary::Arbitrary<'_> for SInt<BITS, LIMBS> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let arbitrary_signed = u.arbitrary::<Signed<BITS, LIMBS>>()?;
-        Ok(SInt(arbitrary_signed))
+impl proptest::arbitrary::Arbitrary for SBytes {
+    type Parameters = proptest::arbitrary::ParamsFor<alloc::vec::Vec<u8>>;
+    type Strategy = proptest::arbitrary::Mapped<alloc::vec::Vec<u8>, Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        use proptest::strategy::Strategy;
+        proptest::arbitrary::any_with::<alloc::vec::Vec<u8>>(args).prop_map(|v| SBytes(v.into()))
     }
 }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -148,7 +148,8 @@ pub mod private {
 pub mod storage;
 #[cfg(feature = "seismic")]
 pub use aliases::{
-    SAddress, SI8, SI16, SI32, SI64, SI128, SI256, SU8, SU16, SU32, SU64, SU128, SU256,
+    SAddress, SBool, SBytes, SFixedBytes, SI8, SI16, SI32, SI64, SI128, SI256, SU8, SU16, SU32,
+    SU64, SU128, SU256,
 };
 #[cfg(feature = "seismic")]
 pub use storage::{FlaggedStorage, PrivateSlot, StorageSlot};

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -85,6 +85,17 @@ impl ExpCtxt<'_> {
             #[cfg(feature = "seismic")]
             Type::Sbool(span) => quote_spanned! {span=> #alloy_sol_types::sol_data::Sbool },
 
+            #[cfg(feature = "seismic")]
+            Type::FixedSbytes(span, size) => {
+                assert!(size.get() <= 32);
+                let size = Literal::u16_unsuffixed(size.get());
+                quote_spanned! {span=> #alloy_sol_types::sol_data::FixedSbytes<#size> }
+            }
+            #[cfg(feature = "seismic")]
+            Type::Sbytes(span) => {
+                quote_spanned! {span=> #alloy_sol_types::sol_data::Sbytes }
+            }
+
             Type::Tuple(ref tuple) => {
                 return tuple.paren_token.surround(tokens, |tokens| {
                     for pair in tuple.types.pairs() {
@@ -177,6 +188,16 @@ impl ExpCtxt<'_> {
             Type::Sbool(span) => {
                 quote_spanned! {span=> #alloy_sol_types::sol_data::Sbool }
             }
+            #[cfg(feature = "seismic")]
+            Type::FixedSbytes(span, size) => {
+                assert!(size.get() <= 32);
+                let size = Literal::u16_unsuffixed(size.get());
+                quote_spanned! {span=> #alloy_sol_types::private::FixedBytes<#size> }
+            }
+            #[cfg(feature = "seismic")]
+            Type::Sbytes(span) => {
+                quote_spanned! {span=> #alloy_sol_types::private::Bytes }
+            }
 
             Type::Tuple(ref tuple) => {
                 return tuple.paren_token.surround(tokens, |tokens| {
@@ -236,9 +257,11 @@ impl ExpCtxt<'_> {
             | Type::Function(_) => 32,
 
             #[cfg(feature = "seismic")]
-            Type::Sint(..) | Type::Suint(..) | Type::Saddress(_) | Type::Sbool(_) => 32,
+            Type::Sint(..) | Type::Suint(..) | Type::Saddress(_) | Type::Sbool(_) | Type::FixedSbytes(..) => 32,
 
             // dynamic types: 1 offset word, 1 length word
+            #[cfg(feature = "seismic")]
+            Type::Sbytes(_) => 64,
             Type::String(_) | Type::Bytes(_) | Type::Array(TypeArray { size: None, .. }) => 64,
 
             // fixed array: size * encoded size

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -186,17 +186,17 @@ impl ExpCtxt<'_> {
             }
             #[cfg(feature = "seismic")]
             Type::Sbool(span) => {
-                quote_spanned! {span=> #alloy_sol_types::sol_data::Sbool }
+                quote_spanned! {span=> #alloy_sol_types::private::primitives::aliases::SBool }
             }
             #[cfg(feature = "seismic")]
             Type::FixedSbytes(span, size) => {
                 assert!(size.get() <= 32);
                 let size = Literal::u16_unsuffixed(size.get());
-                quote_spanned! {span=> #alloy_sol_types::private::FixedBytes<#size> }
+                quote_spanned! {span=> #alloy_sol_types::private::primitives::aliases::SFixedBytes<#size> }
             }
             #[cfg(feature = "seismic")]
             Type::Sbytes(span) => {
-                quote_spanned! {span=> #alloy_sol_types::private::Bytes }
+                quote_spanned! {span=> #alloy_sol_types::private::primitives::aliases::SBytes }
             }
 
             Type::Tuple(ref tuple) => {
@@ -257,7 +257,11 @@ impl ExpCtxt<'_> {
             | Type::Function(_) => 32,
 
             #[cfg(feature = "seismic")]
-            Type::Sint(..) | Type::Suint(..) | Type::Saddress(_) | Type::Sbool(_) | Type::FixedSbytes(..) => 32,
+            Type::Sint(..)
+            | Type::Suint(..)
+            | Type::Saddress(_)
+            | Type::Sbool(_)
+            | Type::FixedSbytes(..) => 32,
 
             // dynamic types: 1 offset word, 1 length word
             #[cfg(feature = "seismic")]

--- a/crates/sol-type-parser/src/root.rs
+++ b/crates/sol-type-parser/src/root.rs
@@ -152,6 +152,16 @@ impl<'a> RootType<'a> {
                     return Err(Error::invalid_size(name));
                 }
 
+                #[cfg(feature = "seismic")]
+                if let Some(sz) = name.strip_prefix("sbytes") {
+                    if let Ok(sz) = sz.parse::<usize>() {
+                        if sz != 0 && sz <= 32 {
+                            return Ok(());
+                        }
+                    }
+                    return Err(Error::invalid_size(name));
+                }
+
                 // fast path both integer types
                 #[cfg(not(feature = "seismic"))]
                 let s = name.strip_prefix('u').unwrap_or(name);

--- a/crates/sol-types/Cargo.toml
+++ b/crates/sol-types/Cargo.toml
@@ -34,8 +34,6 @@ alloy-json-abi = { workspace = true, optional = true }
 # eip712-serde
 serde = { workspace = true, optional = true, features = ["derive"] }
 
-arbitrary = { workspace = true, optional = true }
-
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
     "arbitrary",
@@ -58,5 +56,5 @@ std = ["alloy-primitives/std", "alloy-json-abi?/std", "serde?/std"]
 json = ["dep:alloy-json-abi", "alloy-sol-macro/json"]
 eip712-serde = ["dep:serde", "alloy-primitives/serde"]
 seismic = ["alloy-primitives/seismic", "alloy-sol-macro/seismic"]
-arbitrary = ["dep:arbitrary", "alloy-primitives/arbitrary"]
+arbitrary = ["alloy-primitives/arbitrary"]
 more-tuple-impls = []

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -37,7 +37,7 @@ pub use types::{
 };
 
 #[cfg(feature = "seismic")]
-pub use types::data_type::{Saddress, Sbool, Sbytes, Sint, Suint};
+pub use types::data_type::{FixedSbytes, Saddress, Sbool, Sbytes, Sint, Suint};
 
 pub mod utils;
 

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -36,6 +36,7 @@ pub use types::{
     data_type as sol_data, decode_revert_reason,
 };
 
+#[cfg(feature = "seismic")]
 pub use alloy_primitives::{SBool, SBytes, SFixedBytes};
 #[cfg(feature = "seismic")]
 pub use types::data_type::{FixedSbytes, Saddress, Sbool, Sbytes, Sint, Suint};

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -36,6 +36,7 @@ pub use types::{
     data_type as sol_data, decode_revert_reason,
 };
 
+pub use alloy_primitives::{SBool, SBytes, SFixedBytes};
 #[cfg(feature = "seismic")]
 pub use types::data_type::{FixedSbytes, Saddress, Sbool, Sbytes, Sint, Suint};
 

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -1541,14 +1541,17 @@ mod seismic {
 
     /// Seismic Shielded Fixed Bytes - `sbytesN`
     #[derive(Clone, Copy, Debug)]
-    pub struct Sbytes<const N: usize>;
+    pub struct FixedSbytes<const N: usize>;
 
-    impl<T: Borrow<[u8; N]>, const N: usize> SolTypeValue<Sbytes<N>> for T
+    /// Seismic Shielded Dynamic Bytes - `sbytes`
+    pub struct Sbytes;
+
+    impl<T: Borrow<[u8; N]>, const N: usize> SolTypeValue<FixedSbytes<N>> for T
     where
         ByteCount<N>: SupportedFixedBytes,
     {
         #[inline]
-        fn stv_to_tokens(&self) -> <Sbytes<N> as SolType>::Token<'_> {
+        fn stv_to_tokens(&self) -> <FixedSbytes<N> as SolType>::Token<'_> {
             let mut word = Word::ZERO;
             word[..N].copy_from_slice(self.borrow());
             word.into()
@@ -1556,7 +1559,7 @@ mod seismic {
 
         #[inline]
         fn stv_eip712_data_word(&self) -> Word {
-            SolTypeValue::<Sbytes<N>>::stv_to_tokens(self).0
+            SolTypeValue::<FixedSbytes<N>>::stv_to_tokens(self).0
         }
 
         #[inline]
@@ -1565,7 +1568,7 @@ mod seismic {
         }
     }
 
-    impl<const N: usize> SolType for Sbytes<N>
+    impl<const N: usize> SolType for FixedSbytes<N>
     where
         ByteCount<N>: SupportedFixedBytes,
     {
@@ -1585,6 +1588,53 @@ mod seismic {
         #[inline]
         fn detokenize(token: Self::Token<'_>) -> Self::RustType {
             token.0[..N].try_into().unwrap()
+        }
+    }
+
+    impl<T: ?Sized + AsRef<[u8]>> SolTypeValue<Sbytes> for T {
+        #[inline]
+        fn stv_to_tokens(&self) -> PackedSeqToken<'_> {
+            PackedSeqToken(self.as_ref())
+        }
+
+        #[inline]
+        fn stv_abi_encoded_size(&self) -> usize {
+            let s = self.as_ref();
+            if s.is_empty() { 64 } else { 64 + utils::padded_len(s) }
+        }
+
+        #[inline]
+        fn stv_eip712_data_word(&self) -> Word {
+            keccak256(Sbytes::abi_encode_packed(self))
+        }
+
+        #[inline]
+        fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
+            out.extend_from_slice(self.as_ref());
+        }
+
+        #[inline]
+        fn stv_abi_packed_encoded_size(&self) -> usize {
+            self.as_ref().len()
+        }
+    }
+
+    impl SolType for Sbytes {
+        type RustType = RustBytes;
+        type Token<'a> = PackedSeqToken<'a>;
+
+        const SOL_NAME: &'static str = "sbytes";
+        const ENCODED_SIZE: Option<usize> = None;
+        const PACKED_ENCODED_SIZE: Option<usize> = None;
+
+        #[inline]
+        fn valid_token(_token: &Self::Token<'_>) -> bool {
+            true
+        }
+
+        #[inline]
+        fn detokenize(token: Self::Token<'_>) -> Self::RustType {
+            token.into_bytes()
         }
     }
 }
@@ -1999,5 +2049,293 @@ mod tests {
         );
         assert_eq!(hex::encode(res_ty), hex::encode(expected));
         assert_eq!(hex::encode(res_value), hex::encode(expected));
+    }
+
+    #[cfg(feature = "seismic")]
+    mod seismic_tests {
+        use super::*;
+
+        #[test]
+        fn sbytes_sol_names() {
+            assert_eq!(<FixedSbytes<1> as SolType>::SOL_NAME, "sbytes1");
+            assert_eq!(<FixedSbytes<2> as SolType>::SOL_NAME, "sbytes2");
+            assert_eq!(<FixedSbytes<4> as SolType>::SOL_NAME, "sbytes4");
+            assert_eq!(<FixedSbytes<16> as SolType>::SOL_NAME, "sbytes16");
+            assert_eq!(<FixedSbytes<32> as SolType>::SOL_NAME, "sbytes32");
+        }
+
+        #[test]
+        fn sbytes_encoded_sizes() {
+            assert_encoded_size!(FixedSbytes<1>, Some(32));
+            assert_encoded_size!(FixedSbytes<2>, Some(32));
+            assert_encoded_size!(FixedSbytes<4>, Some(32));
+            assert_encoded_size!(FixedSbytes<16>, Some(32));
+            assert_encoded_size!(FixedSbytes<32>, Some(32));
+        }
+
+        #[test]
+        fn sbytes_packed_encoded_sizes() {
+            assert_eq!(<FixedSbytes<1> as SolType>::PACKED_ENCODED_SIZE, Some(1));
+            assert_eq!(<FixedSbytes<4> as SolType>::PACKED_ENCODED_SIZE, Some(4));
+            assert_eq!(<FixedSbytes<16> as SolType>::PACKED_ENCODED_SIZE, Some(16));
+            assert_eq!(<FixedSbytes<32> as SolType>::PACKED_ENCODED_SIZE, Some(32));
+        }
+
+        #[test]
+        fn sbytes_not_dynamic() {
+            assert!(!<FixedSbytes<1> as SolType>::DYNAMIC);
+            assert!(!<FixedSbytes<16> as SolType>::DYNAMIC);
+            assert!(!<FixedSbytes<32> as SolType>::DYNAMIC);
+        }
+
+        #[test]
+        fn sbytes_tokenize_roundtrip() {
+            // sbytes1
+            let val: [u8; 1] = [0xAB];
+            let token = <FixedSbytes<1>>::tokenize(&val);
+            let back = <FixedSbytes<1>>::detokenize(token);
+            assert_eq!(back, val);
+
+            // sbytes16
+            let val: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            let token = <FixedSbytes<16>>::tokenize(&val);
+            let back = <FixedSbytes<16>>::detokenize(token);
+            assert_eq!(back, val);
+
+            // sbytes32
+            let val: [u8; 32] = core::array::from_fn(|i| i as u8 + 1);
+            let token = <FixedSbytes<32>>::tokenize(&val);
+            let back = <FixedSbytes<32>>::detokenize(token);
+            assert_eq!(back, val);
+        }
+
+        #[test]
+        fn sbytes_abi_encode_decode() {
+            let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+            let encoded = <FixedSbytes<4>>::abi_encode(&val);
+            assert_eq!(encoded.len(), 32);
+            // first 4 bytes should be our data, rest zero-padded
+            assert_eq!(&encoded[..4], &val);
+            assert!(encoded[4..].iter().all(|&b| b == 0));
+
+            let decoded = <FixedSbytes<4>>::abi_decode(&encoded).unwrap();
+            assert_eq!(decoded, val);
+        }
+
+        #[test]
+        fn sbytes_valid_token() {
+            // valid: zero-padded after N bytes
+            let mut word = Word::ZERO;
+            word[0] = 0xFF;
+            assert!(<FixedSbytes<1>>::valid_token(&WordToken(word)));
+
+            // invalid: non-zero bytes after position N
+            let mut word = Word::ZERO;
+            word[0] = 0xFF;
+            word[1] = 0x01; // this byte should be zero for sbytes1
+            assert!(!<FixedSbytes<1>>::valid_token(&WordToken(word)));
+
+            // sbytes32: all bytes valid, no padding
+            let word = Word::new(core::array::from_fn(|i| i as u8 + 1));
+            assert!(<FixedSbytes<32>>::valid_token(&WordToken(word)));
+        }
+
+        #[test]
+        fn sbytes_in_sol_macro() {
+            // Test sbytes in function signatures
+            sol! {
+                function takeSbytes(sbytes32 data) returns (sbytes16);
+            }
+
+            sol! {
+                function multiSbytes(sbytes1 a, sbytes4 b, sbytes32 c) returns (sbytes16 out);
+            }
+
+            // Test sbytes in structs
+            sol! {
+                struct SbytesStruct {
+                    sbytes1 small;
+                    sbytes16 medium;
+                    sbytes32 large;
+                }
+            }
+
+            // Test sbytes in events
+            sol! {
+                event SbytesEvent(sbytes32 indexed data, sbytes4 extra);
+            }
+
+            // Test sbytes in errors
+            sol! {
+                error SbytesError(sbytes32 data);
+            }
+
+            // Verify encoding roundtrip through sol macro types
+            use crate::SolCall;
+            let call = takeSbytesCall { data: [0xAB; 32].into() };
+            let encoded = <takeSbytesCall as SolCall>::abi_encode(&call);
+            let decoded = <takeSbytesCall as SolCall>::abi_decode(&encoded).unwrap();
+            assert_eq!(decoded.data, call.data);
+        }
+
+        #[test]
+        fn sbytes_mixed_with_other_shielded_types() {
+            sol! {
+                struct MixedShielded {
+                    sbytes32 data;
+                    suint256 amount;
+                    saddress recipient;
+                    sint128 delta;
+                    sbytes4 tag;
+                }
+            }
+
+            sol! {
+                function processShielded(
+                    sbytes32 data,
+                    suint256 amount,
+                    saddress to
+                ) returns (sbytes4 result);
+            }
+        }
+
+        #[test]
+        fn dynamic_sbytes_sol_name() {
+            assert_eq!(<Sbytes as SolType>::SOL_NAME, "sbytes");
+        }
+
+        #[test]
+        fn dynamic_sbytes_is_dynamic() {
+            assert!(<Sbytes as SolType>::DYNAMIC);
+            assert_eq!(<Sbytes as SolType>::ENCODED_SIZE, None);
+            assert_eq!(<Sbytes as SolType>::PACKED_ENCODED_SIZE, None);
+        }
+
+        #[test]
+        fn dynamic_sbytes_tokenize_roundtrip() {
+            let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03];
+            let token = <Sbytes>::tokenize(&val);
+            let back = <Sbytes>::detokenize(token);
+            assert_eq!(back, val);
+
+            // empty
+            let val: Vec<u8> = vec![];
+            let token = <Sbytes>::tokenize(&val);
+            let back = <Sbytes>::detokenize(token);
+            assert_eq!(back, val);
+        }
+
+        #[test]
+        fn dynamic_sbytes_in_sol_macro() {
+            sol! {
+                function takeDynSbytes(sbytes data) returns (sbytes);
+            }
+
+            sol! {
+                struct DynSbytesStruct {
+                    sbytes data;
+                    suint256 amount;
+                    sbytes32 tag;
+                }
+            }
+
+            sol! {
+                event DynSbytesEvent(sbytes data, sbytes32 indexed tag);
+            }
+
+            // Verify encoding roundtrip
+            use crate::SolCall;
+            let call = takeDynSbytesCall { data: vec![0xAB, 0xCD, 0xEF].into() };
+            let encoded = <takeDynSbytesCall as SolCall>::abi_encode(&call);
+            let decoded = <takeDynSbytesCall as SolCall>::abi_decode(&encoded).unwrap();
+            assert_eq!(decoded.data, call.data);
+        }
+
+        #[test]
+        fn mixed_fixed_and_dynamic_sbytes() {
+            sol! {
+                function mixedSbytes(sbytes32 fixed, sbytes dynamic) returns (sbytes4 tag);
+            }
+
+            sol! {
+                struct MixedSbytesStruct {
+                    sbytes32 fixed;
+                    sbytes dynamic;
+                    sbytes4 tag;
+                }
+            }
+        }
+
+        #[test]
+        fn sbytes_in_arrays() {
+            sol! {
+                function takeArrayOfFixedSbytes(sbytes32[] data) returns (sbytes4[3] tags);
+            }
+
+            sol! {
+                function takeArrayOfDynSbytes(sbytes[] data) returns (sbytes[] result);
+            }
+
+            sol! {
+                struct ArrayStruct {
+                    sbytes32[] fixedArr;
+                    sbytes[] dynArr;
+                    sbytes4[2] smallArr;
+                }
+            }
+        }
+
+        #[test]
+        #[test]
+        fn sbytes_in_tuples() {
+            type SbytesTuple = sol! { (sbytes32, sbytes, sbytes4) };
+
+            let val: ([u8; 32], Vec<u8>, [u8; 4]) = (
+                [0xAB; 32].into(),
+                vec![1, 2, 3],
+                [0xDE, 0xAD, 0xBE, 0xEF],
+            );
+            let encoded = SbytesTuple::abi_encode(&val);
+            let decoded = SbytesTuple::abi_decode(&encoded).unwrap();
+            assert_eq!(decoded.0, val.0);
+            assert_eq!(decoded.1, val.1);
+            assert_eq!(decoded.2, val.2);
+        }
+
+        #[test]
+        fn dynamic_sbytes_direct_abi_roundtrip() {
+            // Small payload
+            let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
+            let encoded = Sbytes::abi_encode(&val);
+            let decoded = Sbytes::abi_decode(&encoded).unwrap();
+            assert_eq!(decoded, val);
+
+            // Empty payload
+            let val: Vec<u8> = vec![];
+            let encoded = Sbytes::abi_encode(&val);
+            let decoded = Sbytes::abi_decode(&encoded).unwrap();
+            assert_eq!(decoded, val);
+
+            // Large payload (> 32 bytes)
+            let val: Vec<u8> = (0..100).collect();
+            let encoded = Sbytes::abi_encode(&val);
+            let decoded = Sbytes::abi_decode(&encoded).unwrap();
+            assert_eq!(decoded, val);
+        }
+
+        #[test]
+        fn fixed_sbytes_boundary_sizes() {
+            // sbytes1 - minimum
+            assert_eq!(<FixedSbytes<1> as SolType>::SOL_NAME, "sbytes1");
+            let val: [u8; 1] = [0xFF];
+            let roundtrip = FixedSbytes::<1>::abi_decode(&FixedSbytes::<1>::abi_encode(&val)).unwrap();
+            assert_eq!(roundtrip, val);
+
+            // sbytes32 - maximum
+            assert_eq!(<FixedSbytes<32> as SolType>::SOL_NAME, "sbytes32");
+            let val: [u8; 32] = core::array::from_fn(|i| i as u8);
+            let roundtrip = FixedSbytes::<32>::abi_decode(&FixedSbytes::<32>::abi_encode(&val)).unwrap();
+            assert_eq!(roundtrip, val);
+        }
     }
 }

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -1540,7 +1540,8 @@ mod seismic {
         #[inline]
         fn stv_to_tokens(&self) -> <FixedSbytes<N> as SolType>::Token<'_> {
             let mut word = Word::ZERO;
-            word[..N].copy_from_slice(&self.borrow().0.0);
+            // SFixedBytes<N> -> FixedBytes<N> -> [u8; N]
+            word[..N].copy_from_slice(&self.borrow().0 .0);
             word.into()
         }
 
@@ -1551,7 +1552,8 @@ mod seismic {
 
         #[inline]
         fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
-            out.extend_from_slice(&self.borrow().0.0);
+            // SFixedBytes<N> -> FixedBytes<N> -> [u8; N]
+            out.extend_from_slice(&self.borrow().0 .0);
         }
     }
 

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -2202,5 +2202,54 @@ mod tests {
         // FixedSbytes<32>: all bytes valid, no padding required
         let word = Word::new(core::array::from_fn(|i| i as u8 + 1));
         assert!(<FixedSbytes<32>>::valid_token(&WordToken(word)));
+
+        // Sbool: valid when first 31 bytes are zero
+        assert!(<Sbool>::valid_token(&WordToken(Word::with_last_byte(1))));
+        assert!(<Sbool>::valid_token(&WordToken(Word::ZERO)));
+
+        // Sbool: invalid when non-zero in first 31 bytes
+        let mut word = Word::ZERO;
+        word[0] = 0x01;
+        assert!(!<Sbool>::valid_token(&WordToken(word)));
+    }
+
+    #[test]
+    #[cfg(feature = "seismic")]
+    fn seismic_custom_encoded_sizes() {
+        macro_rules! custom_and_assert {
+            ($block:tt, $e:expr) => {{
+                sol! {
+                    struct Struct $block
+                }
+                assert_encoded_size!(Struct, $e);
+            }};
+        }
+        custom_and_assert!({ sbool a; }, Some(32));
+        custom_and_assert!({ sbool a; saddress b; }, Some(64));
+        custom_and_assert!({ suint256 a; sbytes32 b; sint128 c; }, Some(3 * 32));
+        custom_and_assert!({ sbytes a; }, None);
+        custom_and_assert!({ suint256 a; sbytes b; }, None);
+    }
+
+    #[test]
+    #[cfg(feature = "seismic")]
+    fn seismic_encode_packed() {
+        use alloy_primitives::aliases::{SAddress, SBool, SFixedBytes, SUInt};
+
+        let value = (
+            SAddress(RustAddress::with_last_byte(1)),
+            SUInt(U256::from(42)),
+            SBool(true),
+            SFixedBytes(RustFixedBytes::from([0xDE, 0xAD, 0xBE, 0xEF])),
+        );
+
+        let encoded = <sol! { (saddress, suint256, sbool, sbytes4) }>::abi_encode_packed(&value);
+        let expected = hex!(
+            "0000000000000000000000000000000000000001" // saddress: 20 bytes
+            "000000000000000000000000000000000000000000000000000000000000002a" // suint256: 32 bytes
+            "01"                                       // sbool: 1 byte
+            "deadbeef"                                 // sbytes4: 4 bytes
+        );
+        assert_eq!(hex::encode(&encoded), hex::encode(expected));
     }
 }

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -1541,7 +1541,7 @@ mod seismic {
         fn stv_to_tokens(&self) -> <FixedSbytes<N> as SolType>::Token<'_> {
             let mut word = Word::ZERO;
             // SFixedBytes<N> -> FixedBytes<N> -> [u8; N]
-            word[..N].copy_from_slice(&self.borrow().0 .0);
+            word[..N].copy_from_slice(&self.borrow().0.0);
             word.into()
         }
 
@@ -1553,7 +1553,7 @@ mod seismic {
         #[inline]
         fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
             // SFixedBytes<N> -> FixedBytes<N> -> [u8; N]
-            out.extend_from_slice(&self.borrow().0 .0);
+            out.extend_from_slice(&self.borrow().0.0);
         }
     }
 

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -16,13 +16,10 @@ use alloy_primitives::{
 };
 
 #[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SAddress as RustSAddress;
-#[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SBool as RustSBool;
-#[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SBytes as RustSBytes;
-#[cfg(feature = "seismic")]
-use alloy_primitives::aliases::SFixedBytes as RustSFixedBytes;
+use alloy_primitives::aliases::{
+    SAddress as RustSAddress, SBool as RustSBool, SBytes as RustSBytes,
+    SFixedBytes as RustSFixedBytes,
+};
 
 use core::{borrow::Borrow, fmt::*, hash::Hash, marker::PhantomData, ops::*};
 

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -17,6 +17,12 @@ use alloy_primitives::{
 
 #[cfg(feature = "seismic")]
 use alloy_primitives::aliases::SAddress as RustSAddress;
+#[cfg(feature = "seismic")]
+use alloy_primitives::aliases::SBool as RustSBool;
+#[cfg(feature = "seismic")]
+use alloy_primitives::aliases::SBytes as RustSBytes;
+#[cfg(feature = "seismic")]
+use alloy_primitives::aliases::SFixedBytes as RustSFixedBytes;
 
 use core::{borrow::Borrow, fmt::*, hash::Hash, marker::PhantomData, ops::*};
 
@@ -1186,39 +1192,14 @@ mod seismic {
     use super::*;
     use alloy_primitives::{Signed as RustSigned, Uint as RustUint};
 
-    /// `Sbool` is our seismic-boolean type. Unlike the legacy `Bool`,
-    /// which uses a plain `bool` in Rust, we store `bool` inside a newtype
-    /// so we can treat it differently if desired (e.g. “shielded bool”).
-    #[derive(Clone, Copy, Debug, PartialEq)]
-    pub struct Sbool(pub bool);
+    /// Sbool - `sbool`
+    #[derive(Clone, Copy, Debug)]
+    pub struct Sbool;
 
-    // 1) Implement `SolType` for `Sbool` in the usual way
-    impl SolType for Sbool {
-        // Because `Sbool` is the final, stored type
-        type RustType = Sbool;
-        type Token<'a> = WordToken;
-
-        const SOL_NAME: &'static str = "sbool";
-        const ENCODED_SIZE: Option<usize> = Some(32);
-        const PACKED_ENCODED_SIZE: Option<usize> = Some(32);
-
-        fn valid_token(token: &Self::Token<'_>) -> bool {
-            utils::check_zeroes(&token.0[..31])
-        }
-
-        fn detokenize(token: Self::Token<'_>) -> Self::RustType {
-            // Non-zero last byte => true
-            Sbool(token.0 != Word::ZERO)
-        }
-    }
-
-    // 2) Implement `SolTypeValue<Sbool>` for `T: Borrow<Sbool>` so references, owned values, etc.,
-    //    can all encode properly.
-    impl<T: Borrow<Sbool>> SolTypeValue<Sbool> for T {
+    impl<T: Borrow<RustSBool>> SolTypeValue<Sbool> for T {
         #[inline]
         fn stv_to_tokens(&self) -> WordToken {
-            let inner = self.borrow();
-            WordToken(Word::with_last_byte(inner.0 as u8))
+            WordToken(Word::with_last_byte(self.borrow().0 as u8))
         }
 
         #[inline]
@@ -1232,11 +1213,20 @@ mod seismic {
         }
     }
 
-    #[cfg(all(feature = "seismic", feature = "arbitrary"))]
-    impl arbitrary::Arbitrary<'_> for Sbool {
-        fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-            let arbitrary_bool = u.arbitrary::<bool>()?;
-            Ok(Sbool(arbitrary_bool))
+    impl SolType for Sbool {
+        type RustType = RustSBool;
+        type Token<'a> = WordToken;
+
+        const SOL_NAME: &'static str = "sbool";
+        const ENCODED_SIZE: Option<usize> = Some(32);
+        const PACKED_ENCODED_SIZE: Option<usize> = Some(32);
+
+        fn valid_token(token: &Self::Token<'_>) -> bool {
+            utils::check_zeroes(&token.0[..31])
+        }
+
+        fn detokenize(token: Self::Token<'_>) -> Self::RustType {
+            RustSBool(token.0 != Word::ZERO)
         }
     }
 
@@ -1546,14 +1536,14 @@ mod seismic {
     /// Seismic Shielded Dynamic Bytes - `sbytes`
     pub struct Sbytes;
 
-    impl<T: Borrow<[u8; N]>, const N: usize> SolTypeValue<FixedSbytes<N>> for T
+    impl<T: Borrow<RustSFixedBytes<N>>, const N: usize> SolTypeValue<FixedSbytes<N>> for T
     where
         ByteCount<N>: SupportedFixedBytes,
     {
         #[inline]
         fn stv_to_tokens(&self) -> <FixedSbytes<N> as SolType>::Token<'_> {
             let mut word = Word::ZERO;
-            word[..N].copy_from_slice(self.borrow());
+            word[..N].copy_from_slice(&self.borrow().0.0);
             word.into()
         }
 
@@ -1564,7 +1554,7 @@ mod seismic {
 
         #[inline]
         fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
-            out.extend_from_slice(self.borrow().as_slice());
+            out.extend_from_slice(&self.borrow().0.0);
         }
     }
 
@@ -1572,7 +1562,7 @@ mod seismic {
     where
         ByteCount<N>: SupportedFixedBytes,
     {
-        type RustType = RustFixedBytes<N>;
+        type RustType = RustSFixedBytes<N>;
         type Token<'a> = WordToken;
 
         const SOL_NAME: &'static str =
@@ -1587,19 +1577,19 @@ mod seismic {
 
         #[inline]
         fn detokenize(token: Self::Token<'_>) -> Self::RustType {
-            token.0[..N].try_into().unwrap()
+            RustSFixedBytes(token.0[..N].try_into().unwrap())
         }
     }
 
-    impl<T: ?Sized + AsRef<[u8]>> SolTypeValue<Sbytes> for T {
+    impl<T: Borrow<RustSBytes>> SolTypeValue<Sbytes> for T {
         #[inline]
         fn stv_to_tokens(&self) -> PackedSeqToken<'_> {
-            PackedSeqToken(self.as_ref())
+            PackedSeqToken(self.borrow().0.as_ref())
         }
 
         #[inline]
         fn stv_abi_encoded_size(&self) -> usize {
-            let s = self.as_ref();
+            let s = self.borrow().0.as_ref();
             if s.is_empty() { 64 } else { 64 + utils::padded_len(s) }
         }
 
@@ -1610,17 +1600,17 @@ mod seismic {
 
         #[inline]
         fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
-            out.extend_from_slice(self.as_ref());
+            out.extend_from_slice(self.borrow().0.as_ref());
         }
 
         #[inline]
         fn stv_abi_packed_encoded_size(&self) -> usize {
-            self.as_ref().len()
+            self.borrow().0.len()
         }
     }
 
     impl SolType for Sbytes {
-        type RustType = RustBytes;
+        type RustType = RustSBytes;
         type Token<'a> = PackedSeqToken<'a>;
 
         const SOL_NAME: &'static str = "sbytes";
@@ -1634,7 +1624,7 @@ mod seismic {
 
         #[inline]
         fn detokenize(token: Self::Token<'_>) -> Self::RustType {
-            token.into_bytes()
+            RustSBytes(token.into_bytes())
         }
     }
 }
@@ -1890,6 +1880,17 @@ mod tests {
         roundtrip_i256(Int<256>: I256);
     }
 
+    #[cfg(feature = "seismic")]
+    roundtrip! {
+        roundtrip_saddress(Saddress: alloy_primitives::aliases::SAddress);
+        roundtrip_sbool(Sbool: alloy_primitives::aliases::SBool);
+        roundtrip_sbytes(Sbytes: alloy_primitives::aliases::SBytes);
+        roundtrip_fixed_sbytes_16(FixedSbytes<16>: alloy_primitives::aliases::SFixedBytes<16>);
+        roundtrip_fixed_sbytes_32(FixedSbytes<32>: alloy_primitives::aliases::SFixedBytes<32>);
+        roundtrip_su256(Suint<256>: alloy_primitives::aliases::SU256);
+        roundtrip_si256(Sint<256>: alloy_primitives::aliases::SI256);
+    }
+
     #[test]
     fn tokenize_uint() {
         macro_rules! test {
@@ -2110,23 +2111,26 @@ mod tests {
     #[test]
     #[cfg(feature = "seismic")]
     fn seismic_tokenize_detokenize() {
-        use alloy_primitives::aliases::{SAddress, SI256, SU256};
+        use alloy_primitives::aliases::{SAddress, SBool, SBytes, SFixedBytes, SInt, SUInt};
 
         // FixedSbytes
-        let val: [u8; 1] = [0xAB];
+        let val = SFixedBytes(RustFixedBytes::from([0xAB]));
         assert_eq!(<FixedSbytes<1>>::detokenize(<FixedSbytes<1>>::tokenize(&val)), val);
 
-        let val: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let val = SFixedBytes(RustFixedBytes::from([
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        ]));
         assert_eq!(<FixedSbytes<16>>::detokenize(<FixedSbytes<16>>::tokenize(&val)), val);
 
-        let val: [u8; 32] = core::array::from_fn(|i| i as u8 + 1);
+        let val =
+            SFixedBytes(RustFixedBytes::from(core::array::from_fn::<u8, 32, _>(|i| i as u8 + 1)));
         assert_eq!(<FixedSbytes<32>>::detokenize(<FixedSbytes<32>>::tokenize(&val)), val);
 
         // Sbytes (dynamic)
-        let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let val = SBytes(vec![0xDE, 0xAD, 0xBE, 0xEF].into());
         assert_eq!(<Sbytes>::detokenize(<Sbytes>::tokenize(&val)), val);
 
-        let val: Vec<u8> = vec![];
+        let val = SBytes(vec![].into());
         assert_eq!(<Sbytes>::detokenize(<Sbytes>::tokenize(&val)), val);
 
         // Saddress
@@ -2134,46 +2138,51 @@ mod tests {
         assert_eq!(<Saddress>::detokenize(<Saddress>::tokenize(&val)), val);
 
         // Suint / Sint
-        let val = SU256(U256::from(42));
+        let val = SUInt(U256::from(42));
         assert_eq!(<Suint<256>>::detokenize(<Suint<256>>::tokenize(&val)), val);
 
-        let val = SI256(I256::try_from(-42i64).unwrap());
+        let val = SInt(I256::try_from(-42i64).unwrap());
         assert_eq!(<Sint<256>>::detokenize(<Sint<256>>::tokenize(&val)), val);
 
         // Sbool
-        let val = Sbool(true);
+        let val = SBool(true);
         assert_eq!(<super::Sbool>::detokenize(<super::Sbool>::tokenize(&val)), val);
 
-        let val = Sbool(false);
+        let val = SBool(false);
         assert_eq!(<super::Sbool>::detokenize(<super::Sbool>::tokenize(&val)), val);
     }
 
     #[test]
     #[cfg(feature = "seismic")]
     fn seismic_abi_encode_decode() {
+        use alloy_primitives::aliases::{SBytes, SFixedBytes};
+
         // FixedSbytes: encode is zero-padded to 32 bytes
-        let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+        let val = SFixedBytes(RustFixedBytes::from([0xDE, 0xAD, 0xBE, 0xEF]));
         let encoded = <FixedSbytes<4>>::abi_encode(&val);
         assert_eq!(encoded.len(), 32);
-        assert_eq!(&encoded[..4], &val);
+        assert_eq!(&encoded[..4], &val.0.0);
         assert!(encoded[4..].iter().all(|&b| b == 0));
         assert_eq!(<FixedSbytes<4>>::abi_decode(&encoded).unwrap(), val);
 
         // FixedSbytes boundary: sbytes1 and sbytes32
-        let val: [u8; 1] = [0xFF];
+        let val = SFixedBytes(RustFixedBytes::from([0xFF]));
         assert_eq!(FixedSbytes::<1>::abi_decode(&FixedSbytes::<1>::abi_encode(&val)).unwrap(), val);
 
-        let val: [u8; 32] = core::array::from_fn(|i| i as u8);
-        assert_eq!(FixedSbytes::<32>::abi_decode(&FixedSbytes::<32>::abi_encode(&val)).unwrap(), val);
+        let val = SFixedBytes(RustFixedBytes::from(core::array::from_fn::<u8, 32, _>(|i| i as u8)));
+        assert_eq!(
+            FixedSbytes::<32>::abi_decode(&FixedSbytes::<32>::abi_encode(&val)).unwrap(),
+            val
+        );
 
         // Sbytes (dynamic): small, empty, and large payloads
-        let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let val = SBytes(vec![0xDE, 0xAD, 0xBE, 0xEF].into());
         assert_eq!(Sbytes::abi_decode(&Sbytes::abi_encode(&val)).unwrap(), val);
 
-        let val: Vec<u8> = vec![];
+        let val = SBytes(vec![].into());
         assert_eq!(Sbytes::abi_decode(&Sbytes::abi_encode(&val)).unwrap(), val);
 
-        let val: Vec<u8> = (0..100).collect();
+        let val: SBytes = (0..100).collect::<Vec<u8>>().into();
         assert_eq!(Sbytes::abi_decode(&Sbytes::abi_encode(&val)).unwrap(), val);
     }
 
@@ -2195,5 +2204,4 @@ mod tests {
         let word = Word::new(core::array::from_fn(|i| i as u8 + 1));
         assert!(<FixedSbytes<32>>::valid_token(&WordToken(word)));
     }
-
 }

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -1680,6 +1680,26 @@ mod tests {
         assert_name!((Uint<8>,), "(uint8)");
         assert_name!((Uint<8>, Bool), "(uint8,bool)");
         assert_name!((Uint<8>, Bool, FixedArray<Address, 4>), "(uint8,bool,address[4])");
+
+        #[cfg(feature = "seismic")]
+        {
+            assert_name!(Saddress, "saddress");
+            assert_name!(Sbool, "sbool");
+            assert_name!(Sint<8>, "sint8");
+            assert_name!(Sint<256>, "sint256");
+            assert_name!(Suint<8>, "suint8");
+            assert_name!(Suint<256>, "suint256");
+            assert_name!(FixedSbytes<1>, "sbytes1");
+            assert_name!(FixedSbytes<16>, "sbytes16");
+            assert_name!(FixedSbytes<32>, "sbytes32");
+            assert_name!(Sbytes, "sbytes");
+
+            assert_name!(Array<Suint<256>>, "suint256[]");
+            assert_name!(Array<Sbytes>, "sbytes[]");
+            assert_name!(FixedArray<FixedSbytes<32>, 3>, "sbytes32[3]");
+            assert_name!((Suint<256>, Saddress), "(suint256,saddress)");
+            assert_name!((FixedSbytes<32>, Sbytes), "(sbytes32,sbytes)");
+        }
     }
 
     macro_rules! assert_encoded_size {
@@ -1716,6 +1736,30 @@ mod tests {
         assert_encoded_size!(Bytes, None);
         assert_encoded_size!(String, None);
 
+        #[cfg(feature = "seismic")]
+        {
+            assert_encoded_size!(Saddress, Some(32));
+            assert_encoded_size!(Sbool, Some(32));
+            assert_encoded_size!(Sint<8>, Some(32));
+            assert_encoded_size!(Sint<256>, Some(32));
+            assert_encoded_size!(Suint<8>, Some(32));
+            assert_encoded_size!(Suint<256>, Some(32));
+            assert_encoded_size!(FixedSbytes<1>, Some(32));
+            assert_encoded_size!(FixedSbytes<16>, Some(32));
+            assert_encoded_size!(FixedSbytes<32>, Some(32));
+            assert_encoded_size!(Sbytes, None);
+
+            assert_encoded_size!(Array<Suint<256>>, None);
+            assert_encoded_size!(Array<Sbytes>, None);
+            assert_encoded_size!(FixedArray<Suint<256>, 0>, Some(0));
+            assert_encoded_size!(FixedArray<Suint<256>, 1>, Some(32));
+            assert_encoded_size!(FixedArray<Suint<256>, 2>, Some(64));
+            assert_encoded_size!(FixedArray<FixedSbytes<32>, 2>, Some(64));
+            assert_encoded_size!(FixedArray<Sbytes, 0>, None);
+            assert_encoded_size!(FixedArray<Sbytes, 1>, None);
+            assert_encoded_size!(FixedArray<Sbytes, 2>, None);
+        }
+
         assert_encoded_size!(Array<()>, None);
         assert_encoded_size!(Array<Uint<8>>, None);
         assert_encoded_size!(Array<Bytes>, None);
@@ -1738,6 +1782,14 @@ mod tests {
         assert_encoded_size!((Uint<8>, Bool, FixedArray<Address, 4>), Some(6 * 32));
         assert_encoded_size!((Bytes,), None);
         assert_encoded_size!((Uint<8>, Bytes), None);
+
+        #[cfg(feature = "seismic")]
+        {
+            assert_encoded_size!((Suint<256>,), Some(32));
+            assert_encoded_size!((Suint<256>, Saddress), Some(64));
+            assert_encoded_size!((Suint<256>, Sbytes), None);
+            assert_encoded_size!((FixedSbytes<32>, Suint<256>, Saddress), Some(3 * 32));
+        }
     }
 
     #[test]
@@ -2051,291 +2103,97 @@ mod tests {
         assert_eq!(hex::encode(res_value), hex::encode(expected));
     }
 
+    // =========================================================================
+    // Seismic shielded type tests
+    // =========================================================================
+
+    #[test]
     #[cfg(feature = "seismic")]
-    mod seismic_tests {
-        use super::*;
+    fn seismic_tokenize_detokenize() {
+        use alloy_primitives::aliases::{SAddress, SI256, SU256};
 
-        #[test]
-        fn sbytes_sol_names() {
-            assert_eq!(<FixedSbytes<1> as SolType>::SOL_NAME, "sbytes1");
-            assert_eq!(<FixedSbytes<2> as SolType>::SOL_NAME, "sbytes2");
-            assert_eq!(<FixedSbytes<4> as SolType>::SOL_NAME, "sbytes4");
-            assert_eq!(<FixedSbytes<16> as SolType>::SOL_NAME, "sbytes16");
-            assert_eq!(<FixedSbytes<32> as SolType>::SOL_NAME, "sbytes32");
-        }
+        // FixedSbytes
+        let val: [u8; 1] = [0xAB];
+        assert_eq!(<FixedSbytes<1>>::detokenize(<FixedSbytes<1>>::tokenize(&val)), val);
 
-        #[test]
-        fn sbytes_encoded_sizes() {
-            assert_encoded_size!(FixedSbytes<1>, Some(32));
-            assert_encoded_size!(FixedSbytes<2>, Some(32));
-            assert_encoded_size!(FixedSbytes<4>, Some(32));
-            assert_encoded_size!(FixedSbytes<16>, Some(32));
-            assert_encoded_size!(FixedSbytes<32>, Some(32));
-        }
+        let val: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        assert_eq!(<FixedSbytes<16>>::detokenize(<FixedSbytes<16>>::tokenize(&val)), val);
 
-        #[test]
-        fn sbytes_packed_encoded_sizes() {
-            assert_eq!(<FixedSbytes<1> as SolType>::PACKED_ENCODED_SIZE, Some(1));
-            assert_eq!(<FixedSbytes<4> as SolType>::PACKED_ENCODED_SIZE, Some(4));
-            assert_eq!(<FixedSbytes<16> as SolType>::PACKED_ENCODED_SIZE, Some(16));
-            assert_eq!(<FixedSbytes<32> as SolType>::PACKED_ENCODED_SIZE, Some(32));
-        }
+        let val: [u8; 32] = core::array::from_fn(|i| i as u8 + 1);
+        assert_eq!(<FixedSbytes<32>>::detokenize(<FixedSbytes<32>>::tokenize(&val)), val);
 
-        #[test]
-        fn sbytes_not_dynamic() {
-            assert!(!<FixedSbytes<1> as SolType>::DYNAMIC);
-            assert!(!<FixedSbytes<16> as SolType>::DYNAMIC);
-            assert!(!<FixedSbytes<32> as SolType>::DYNAMIC);
-        }
+        // Sbytes (dynamic)
+        let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        assert_eq!(<Sbytes>::detokenize(<Sbytes>::tokenize(&val)), val);
 
-        #[test]
-        fn sbytes_tokenize_roundtrip() {
-            // sbytes1
-            let val: [u8; 1] = [0xAB];
-            let token = <FixedSbytes<1>>::tokenize(&val);
-            let back = <FixedSbytes<1>>::detokenize(token);
-            assert_eq!(back, val);
+        let val: Vec<u8> = vec![];
+        assert_eq!(<Sbytes>::detokenize(<Sbytes>::tokenize(&val)), val);
 
-            // sbytes16
-            let val: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-            let token = <FixedSbytes<16>>::tokenize(&val);
-            let back = <FixedSbytes<16>>::detokenize(token);
-            assert_eq!(back, val);
+        // Saddress
+        let val = SAddress(RustAddress::with_last_byte(0x42));
+        assert_eq!(<Saddress>::detokenize(<Saddress>::tokenize(&val)), val);
 
-            // sbytes32
-            let val: [u8; 32] = core::array::from_fn(|i| i as u8 + 1);
-            let token = <FixedSbytes<32>>::tokenize(&val);
-            let back = <FixedSbytes<32>>::detokenize(token);
-            assert_eq!(back, val);
-        }
+        // Suint / Sint
+        let val = SU256(U256::from(42));
+        assert_eq!(<Suint<256>>::detokenize(<Suint<256>>::tokenize(&val)), val);
 
-        #[test]
-        fn sbytes_abi_encode_decode() {
-            let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
-            let encoded = <FixedSbytes<4>>::abi_encode(&val);
-            assert_eq!(encoded.len(), 32);
-            // first 4 bytes should be our data, rest zero-padded
-            assert_eq!(&encoded[..4], &val);
-            assert!(encoded[4..].iter().all(|&b| b == 0));
+        let val = SI256(I256::try_from(-42i64).unwrap());
+        assert_eq!(<Sint<256>>::detokenize(<Sint<256>>::tokenize(&val)), val);
 
-            let decoded = <FixedSbytes<4>>::abi_decode(&encoded).unwrap();
-            assert_eq!(decoded, val);
-        }
+        // Sbool
+        let val = Sbool(true);
+        assert_eq!(<super::Sbool>::detokenize(<super::Sbool>::tokenize(&val)), val);
 
-        #[test]
-        fn sbytes_valid_token() {
-            // valid: zero-padded after N bytes
-            let mut word = Word::ZERO;
-            word[0] = 0xFF;
-            assert!(<FixedSbytes<1>>::valid_token(&WordToken(word)));
-
-            // invalid: non-zero bytes after position N
-            let mut word = Word::ZERO;
-            word[0] = 0xFF;
-            word[1] = 0x01; // this byte should be zero for sbytes1
-            assert!(!<FixedSbytes<1>>::valid_token(&WordToken(word)));
-
-            // sbytes32: all bytes valid, no padding
-            let word = Word::new(core::array::from_fn(|i| i as u8 + 1));
-            assert!(<FixedSbytes<32>>::valid_token(&WordToken(word)));
-        }
-
-        #[test]
-        fn sbytes_in_sol_macro() {
-            // Test sbytes in function signatures
-            sol! {
-                function takeSbytes(sbytes32 data) returns (sbytes16);
-            }
-
-            sol! {
-                function multiSbytes(sbytes1 a, sbytes4 b, sbytes32 c) returns (sbytes16 out);
-            }
-
-            // Test sbytes in structs
-            sol! {
-                struct SbytesStruct {
-                    sbytes1 small;
-                    sbytes16 medium;
-                    sbytes32 large;
-                }
-            }
-
-            // Test sbytes in events
-            sol! {
-                event SbytesEvent(sbytes32 indexed data, sbytes4 extra);
-            }
-
-            // Test sbytes in errors
-            sol! {
-                error SbytesError(sbytes32 data);
-            }
-
-            // Verify encoding roundtrip through sol macro types
-            use crate::SolCall;
-            let call = takeSbytesCall { data: [0xAB; 32].into() };
-            let encoded = <takeSbytesCall as SolCall>::abi_encode(&call);
-            let decoded = <takeSbytesCall as SolCall>::abi_decode(&encoded).unwrap();
-            assert_eq!(decoded.data, call.data);
-        }
-
-        #[test]
-        fn sbytes_mixed_with_other_shielded_types() {
-            sol! {
-                struct MixedShielded {
-                    sbytes32 data;
-                    suint256 amount;
-                    saddress recipient;
-                    sint128 delta;
-                    sbytes4 tag;
-                }
-            }
-
-            sol! {
-                function processShielded(
-                    sbytes32 data,
-                    suint256 amount,
-                    saddress to
-                ) returns (sbytes4 result);
-            }
-        }
-
-        #[test]
-        fn dynamic_sbytes_sol_name() {
-            assert_eq!(<Sbytes as SolType>::SOL_NAME, "sbytes");
-        }
-
-        #[test]
-        fn dynamic_sbytes_is_dynamic() {
-            assert!(<Sbytes as SolType>::DYNAMIC);
-            assert_eq!(<Sbytes as SolType>::ENCODED_SIZE, None);
-            assert_eq!(<Sbytes as SolType>::PACKED_ENCODED_SIZE, None);
-        }
-
-        #[test]
-        fn dynamic_sbytes_tokenize_roundtrip() {
-            let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03];
-            let token = <Sbytes>::tokenize(&val);
-            let back = <Sbytes>::detokenize(token);
-            assert_eq!(back, val);
-
-            // empty
-            let val: Vec<u8> = vec![];
-            let token = <Sbytes>::tokenize(&val);
-            let back = <Sbytes>::detokenize(token);
-            assert_eq!(back, val);
-        }
-
-        #[test]
-        fn dynamic_sbytes_in_sol_macro() {
-            sol! {
-                function takeDynSbytes(sbytes data) returns (sbytes);
-            }
-
-            sol! {
-                struct DynSbytesStruct {
-                    sbytes data;
-                    suint256 amount;
-                    sbytes32 tag;
-                }
-            }
-
-            sol! {
-                event DynSbytesEvent(sbytes data, sbytes32 indexed tag);
-            }
-
-            // Verify encoding roundtrip
-            use crate::SolCall;
-            let call = takeDynSbytesCall { data: vec![0xAB, 0xCD, 0xEF].into() };
-            let encoded = <takeDynSbytesCall as SolCall>::abi_encode(&call);
-            let decoded = <takeDynSbytesCall as SolCall>::abi_decode(&encoded).unwrap();
-            assert_eq!(decoded.data, call.data);
-        }
-
-        #[test]
-        fn mixed_fixed_and_dynamic_sbytes() {
-            sol! {
-                function mixedSbytes(sbytes32 fixed, sbytes dynamic) returns (sbytes4 tag);
-            }
-
-            sol! {
-                struct MixedSbytesStruct {
-                    sbytes32 fixed;
-                    sbytes dynamic;
-                    sbytes4 tag;
-                }
-            }
-        }
-
-        #[test]
-        fn sbytes_in_arrays() {
-            sol! {
-                function takeArrayOfFixedSbytes(sbytes32[] data) returns (sbytes4[3] tags);
-            }
-
-            sol! {
-                function takeArrayOfDynSbytes(sbytes[] data) returns (sbytes[] result);
-            }
-
-            sol! {
-                struct ArrayStruct {
-                    sbytes32[] fixedArr;
-                    sbytes[] dynArr;
-                    sbytes4[2] smallArr;
-                }
-            }
-        }
-
-        #[test]
-        #[test]
-        fn sbytes_in_tuples() {
-            type SbytesTuple = sol! { (sbytes32, sbytes, sbytes4) };
-
-            let val: ([u8; 32], Vec<u8>, [u8; 4]) = (
-                [0xAB; 32].into(),
-                vec![1, 2, 3],
-                [0xDE, 0xAD, 0xBE, 0xEF],
-            );
-            let encoded = SbytesTuple::abi_encode(&val);
-            let decoded = SbytesTuple::abi_decode(&encoded).unwrap();
-            assert_eq!(decoded.0, val.0);
-            assert_eq!(decoded.1, val.1);
-            assert_eq!(decoded.2, val.2);
-        }
-
-        #[test]
-        fn dynamic_sbytes_direct_abi_roundtrip() {
-            // Small payload
-            let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
-            let encoded = Sbytes::abi_encode(&val);
-            let decoded = Sbytes::abi_decode(&encoded).unwrap();
-            assert_eq!(decoded, val);
-
-            // Empty payload
-            let val: Vec<u8> = vec![];
-            let encoded = Sbytes::abi_encode(&val);
-            let decoded = Sbytes::abi_decode(&encoded).unwrap();
-            assert_eq!(decoded, val);
-
-            // Large payload (> 32 bytes)
-            let val: Vec<u8> = (0..100).collect();
-            let encoded = Sbytes::abi_encode(&val);
-            let decoded = Sbytes::abi_decode(&encoded).unwrap();
-            assert_eq!(decoded, val);
-        }
-
-        #[test]
-        fn fixed_sbytes_boundary_sizes() {
-            // sbytes1 - minimum
-            assert_eq!(<FixedSbytes<1> as SolType>::SOL_NAME, "sbytes1");
-            let val: [u8; 1] = [0xFF];
-            let roundtrip = FixedSbytes::<1>::abi_decode(&FixedSbytes::<1>::abi_encode(&val)).unwrap();
-            assert_eq!(roundtrip, val);
-
-            // sbytes32 - maximum
-            assert_eq!(<FixedSbytes<32> as SolType>::SOL_NAME, "sbytes32");
-            let val: [u8; 32] = core::array::from_fn(|i| i as u8);
-            let roundtrip = FixedSbytes::<32>::abi_decode(&FixedSbytes::<32>::abi_encode(&val)).unwrap();
-            assert_eq!(roundtrip, val);
-        }
+        let val = Sbool(false);
+        assert_eq!(<super::Sbool>::detokenize(<super::Sbool>::tokenize(&val)), val);
     }
+
+    #[test]
+    #[cfg(feature = "seismic")]
+    fn seismic_abi_encode_decode() {
+        // FixedSbytes: encode is zero-padded to 32 bytes
+        let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+        let encoded = <FixedSbytes<4>>::abi_encode(&val);
+        assert_eq!(encoded.len(), 32);
+        assert_eq!(&encoded[..4], &val);
+        assert!(encoded[4..].iter().all(|&b| b == 0));
+        assert_eq!(<FixedSbytes<4>>::abi_decode(&encoded).unwrap(), val);
+
+        // FixedSbytes boundary: sbytes1 and sbytes32
+        let val: [u8; 1] = [0xFF];
+        assert_eq!(FixedSbytes::<1>::abi_decode(&FixedSbytes::<1>::abi_encode(&val)).unwrap(), val);
+
+        let val: [u8; 32] = core::array::from_fn(|i| i as u8);
+        assert_eq!(FixedSbytes::<32>::abi_decode(&FixedSbytes::<32>::abi_encode(&val)).unwrap(), val);
+
+        // Sbytes (dynamic): small, empty, and large payloads
+        let val: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        assert_eq!(Sbytes::abi_decode(&Sbytes::abi_encode(&val)).unwrap(), val);
+
+        let val: Vec<u8> = vec![];
+        assert_eq!(Sbytes::abi_decode(&Sbytes::abi_encode(&val)).unwrap(), val);
+
+        let val: Vec<u8> = (0..100).collect();
+        assert_eq!(Sbytes::abi_decode(&Sbytes::abi_encode(&val)).unwrap(), val);
+    }
+
+    #[test]
+    #[cfg(feature = "seismic")]
+    fn seismic_valid_token() {
+        // FixedSbytes<1>: valid when zero-padded after byte 0
+        let mut word = Word::ZERO;
+        word[0] = 0xFF;
+        assert!(<FixedSbytes<1>>::valid_token(&WordToken(word)));
+
+        // FixedSbytes<1>: invalid when non-zero after byte 0
+        let mut word = Word::ZERO;
+        word[0] = 0xFF;
+        word[1] = 0x01;
+        assert!(!<FixedSbytes<1>>::valid_token(&WordToken(word)));
+
+        // FixedSbytes<32>: all bytes valid, no padding required
+        let word = Word::new(core::array::from_fn(|i| i as u8 + 1));
+        assert!(<FixedSbytes<32>>::valid_token(&WordToken(word)));
+    }
+
 }

--- a/crates/sol-types/src/types/event/topic.rs
+++ b/crates/sol-types/src/types/event/topic.rs
@@ -124,6 +124,14 @@ where
     word_impl!();
 }
 
+#[cfg(feature = "seismic")]
+impl<const N: usize> EventTopic for FixedSbytes<N>
+where
+    ByteCount<N>: SupportedFixedBytes,
+{
+    word_impl!();
+}
+
 // Bytes-like types - preimage encoding: bytes padded to 32; hash: the bytes
 macro_rules! bytes_impl {
     () => {
@@ -149,6 +157,11 @@ impl EventTopic for String {
 }
 
 impl EventTopic for Bytes {
+    bytes_impl!();
+}
+
+#[cfg(feature = "seismic")]
+impl EventTopic for Sbytes {
     bytes_impl!();
 }
 

--- a/crates/sol-types/src/types/value.rs
+++ b/crates/sol-types/src/types/value.rs
@@ -8,9 +8,6 @@ use crate::{
 use alloc::{borrow::Cow, string::String, vec::Vec};
 use alloy_primitives::{Address, Bytes, FixedBytes, Function, I256, U256, aliases::*};
 
-#[cfg(feature = "seismic")]
-use alloy_sol_types::Sbool;
-
 /// A Solidity value.
 ///
 /// This is a convenience trait that re-exports the logic in [`SolType`] with
@@ -307,8 +304,9 @@ impl_sol_value! {
 
 #[cfg(feature = "seismic")]
 impl_sol_value! {
-    [] Sbool => sol_data::Sbool [];
+    [] SBool => sol_data::Sbool [];
     [] SAddress => sol_data::Saddress [];
+    [const N: usize] SFixedBytes<N> => sol_data::FixedSbytes<N> [where ByteCount<N>: SupportedFixedBytes];
     []     SU8 => sol_data::Suint<8> [];
     []     SU16 => sol_data::Suint<16> [];
     []     SU24 => sol_data::Suint<24> [];
@@ -374,6 +372,20 @@ impl_sol_value! {
     []     SI240 => sol_data::Sint<240> [];
     []     SI248 => sol_data::Sint<248> [];
     []     SI256 => sol_data::Sint<256> [];
+}
+
+#[cfg(feature = "seismic")]
+impl SolValue for SBytes {
+    type SolType = sol_data::Sbytes;
+
+    #[inline]
+    fn abi_encode(&self) -> Vec<u8> {
+        if self.0.is_empty() {
+            crate::abi::EMPTY_BYTES.to_vec()
+        } else {
+            <Self::SolType as SolType>::abi_encode(self)
+        }
+    }
 }
 
 macro_rules! tuple_impls {

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -36,6 +36,40 @@ fn e2e() {
         }
     }
 
+    sol! {
+        struct MyStruct4 {
+            sbytes1 a;
+            sbytes16 b;
+            sbytes32 c;
+            saddress d;
+            suint256 e;
+        }
+    }
+
+    sol! {
+        function shieldedOp(sbytes32 data, suint256 amount, saddress to) returns (sbytes4);
+    }
+
+    sol! {
+        event ShieldedTransfer(sbytes32 indexed payload, saddress indexed from, suint256 value);
+    }
+
+    sol! {
+        error ShieldedError(sbytes32 reason, suint256 code);
+    }
+
+    sol! {
+        function dynamicShielded(sbytes data, sbytes32 tag) returns (sbytes result);
+    }
+
+    sol! {
+        struct DynSbytesStruct {
+            sbytes data;
+            sbytes32 tag;
+            suint256 amount;
+        }
+    }
+
     type MyTuple = sol! {
         (MyStruct, bytes32)
     };

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -28,45 +28,50 @@ fn e2e() {
         }
     }
 
-    sol! {
-        struct MyStruct3 {
-            saddress b;
-            suint256 c;
-            sint248 d;
+    #[cfg(feature = "seismic")]
+    mod seismic_sol {
+        use super::*;
+
+        sol! {
+            struct MyStruct3 {
+                saddress b;
+                suint256 c;
+                sint248 d;
+            }
         }
-    }
 
-    sol! {
-        struct MyStruct4 {
-            sbytes1 a;
-            sbytes16 b;
-            sbytes32 c;
-            saddress d;
-            suint256 e;
+        sol! {
+            struct MyStruct4 {
+                sbytes1 a;
+                sbytes16 b;
+                sbytes32 c;
+                saddress d;
+                suint256 e;
+            }
         }
-    }
 
-    sol! {
-        function shieldedOp(sbytes32 data, suint256 amount, saddress to) returns (sbytes4);
-    }
+        sol! {
+            function shieldedOp(sbytes32 data, suint256 amount, saddress to) returns (sbytes4);
+        }
 
-    sol! {
-        event ShieldedTransfer(sbytes32 indexed payload, saddress indexed from, suint256 value);
-    }
+        sol! {
+            event ShieldedTransfer(sbytes32 indexed payload, saddress indexed from, suint256 value);
+        }
 
-    sol! {
-        error ShieldedError(sbytes32 reason, suint256 code);
-    }
+        sol! {
+            error ShieldedError(sbytes32 reason, suint256 code);
+        }
 
-    sol! {
-        function dynamicShielded(sbytes data, sbytes32 tag) returns (sbytes result);
-    }
+        sol! {
+            function dynamicShielded(sbytes data, sbytes32 tag) returns (sbytes result);
+        }
 
-    sol! {
-        struct DynSbytesStruct {
-            sbytes data;
-            sbytes32 tag;
-            suint256 amount;
+        sol! {
+            struct DynSbytesStruct {
+                sbytes data;
+                sbytes32 tag;
+                suint256 amount;
+            }
         }
     }
 

--- a/crates/syn-solidity/src/macros.rs
+++ b/crates/syn-solidity/src/macros.rs
@@ -282,7 +282,7 @@ macro_rules! make_visitor {
                         | Type::Bytes(_)
                         | Type::FixedBytes(..) => {},
                         #[cfg(feature = "seismic")]
-                        Type::Sint(..) | Type::Suint(..) | Type::Saddress(_) | Type::Sbool(_) => {},
+                        Type::Sint(..) | Type::Suint(..) | Type::Saddress(_) | Type::Sbool(_) | Type::Sbytes(_) | Type::FixedSbytes(..) => {},
                         Type::Array(TypeArray { ty, .. }) => v.visit_type(ty),
                         Type::Tuple(TypeTuple { types, .. }) => {
                             for ty in types {

--- a/crates/syn-solidity/src/type/mod.rs
+++ b/crates/syn-solidity/src/type/mod.rs
@@ -61,6 +61,12 @@ pub enum Type {
     #[cfg(feature = "seismic")]
     /// `sbool`
     Sbool(Span),
+    #[cfg(feature = "seismic")]
+    /// `sbytes`
+    Sbytes(Span),
+    #[cfg(feature = "seismic")]
+    /// `sbytes<size>`
+    FixedSbytes(Span, NonZeroU16),
 
     /// `$ty[$($size)?]`
     Array(TypeArray),
@@ -95,6 +101,10 @@ impl PartialEq for Type {
             (Self::Saddress(_), Self::Saddress(_)) => true,
             #[cfg(feature = "seismic")]
             (Self::Sbool(_), Self::Sbool(_)) => true,
+            #[cfg(feature = "seismic")]
+            (Self::Sbytes(_), Self::Sbytes(_)) => true,
+            #[cfg(feature = "seismic")]
+            (Self::FixedSbytes(_, a), Self::FixedSbytes(_, b)) => a == b,
 
             (Self::Tuple(a), Self::Tuple(b)) => a == b,
             (Self::Array(a), Self::Array(b)) => a == b,
@@ -124,7 +134,9 @@ impl Hash for Type {
             #[cfg(feature = "seismic")]
             Self::Suint(_, size) => size.hash(state),
             #[cfg(feature = "seismic")]
-            Self::Saddress(_) | Self::Sbool(_) => {}
+            Self::Saddress(_) | Self::Sbool(_) | Self::Sbytes(_) => {}
+            #[cfg(feature = "seismic")]
+            Self::FixedSbytes(_, size) => size.hash(state),
 
             Self::Tuple(tuple) => tuple.hash(state),
             Self::Array(array) => array.hash(state),
@@ -157,6 +169,10 @@ impl fmt::Debug for Type {
             Self::Saddress(_) => f.write_str("Saddress"),
             #[cfg(feature = "seismic")]
             Self::Sbool(_) => f.write_str("Sbool"),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => f.write_str("Sbytes"),
+            #[cfg(feature = "seismic")]
+            Self::FixedSbytes(_, size) => f.debug_tuple("FixedSbytes").field(size).finish(),
 
             Self::Tuple(tuple) => tuple.fmt(f),
             Self::Array(array) => array.fmt(f),
@@ -188,6 +204,10 @@ impl fmt::Display for Type {
             Self::Saddress(_) => f.write_str("saddress"),
             #[cfg(feature = "seismic")]
             Self::Sbool(_) => f.write_str("sbool"),
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => f.write_str("sbytes"),
+            #[cfg(feature = "seismic")]
+            Self::FixedSbytes(_, size) => write!(f, "sbytes{size}"),
 
             Self::Tuple(tuple) => tuple.fmt(f),
             Self::Array(array) => array.fmt(f),
@@ -228,7 +248,9 @@ impl Spanned for Type {
             Self::Sint(span, _)
             | Self::Suint(span, _)
             | Self::Saddress(span)
-            | Self::Sbool(span) => *span,
+            | Self::Sbool(span)
+            | Self::Sbytes(span)
+            | Self::FixedSbytes(span, _) => *span,
             Self::Tuple(tuple) => tuple.span(),
             Self::Array(array) => array.span(),
             Self::Function(function) => function.span(),
@@ -256,7 +278,9 @@ impl Spanned for Type {
             Self::Sint(span, _)
             | Self::Suint(span, _)
             | Self::Saddress(span)
-            | Self::Sbool(span) => *span = new_span,
+            | Self::Sbool(span)
+            | Self::Sbytes(span)
+            | Self::FixedSbytes(span, _) => *span = new_span,
 
             Self::Tuple(tuple) => tuple.set_span(new_span),
             Self::Array(array) => array.set_span(new_span),
@@ -326,6 +350,18 @@ impl Type {
                             }
                             Some(size) => Some(Self::Suint(span, size)),
                         }
+                    } else if let Some(s) = s.strip_prefix("sbytes") {
+                        match parse_size(s, span)? {
+                            None => None,
+                            Some(Some(size)) if size.get() > 32 => {
+                                return Err(Error::new(
+                                    span,
+                                    "sbytesX range is 1-32",
+                                ));
+                            }
+                            Some(None) => Some(Self::Sbytes(span)),
+                            Some(Some(size)) => Some(Self::FixedSbytes(span, size)),
+                        }
                     } else {
                         None
                     };
@@ -386,7 +422,7 @@ impl Type {
         {
             let is_seismic_one_word = matches!(
                 self,
-                Self::Saddress(_) | Self::Sint(..) | Self::Suint(..) | Self::Sbool(_)
+                Self::Saddress(_) | Self::Sint(..) | Self::Suint(..) | Self::Sbool(_) | Self::FixedSbytes(..)
             );
             if is_seismic_one_word {
                 return true;
@@ -417,7 +453,9 @@ impl Type {
             | Self::Function(_) => false,
 
             #[cfg(feature = "seismic")]
-            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) => false,
+            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) | Self::FixedSbytes(..) => false,
+            #[cfg(feature = "seismic")]
+            Self::Sbytes(_) => true,
 
             Self::String(_) | Self::Bytes(_) | Self::Custom(_) => true,
 
@@ -491,7 +529,7 @@ impl Type {
             | Self::String(_)
             | Self::Bytes(_) => false,
             #[cfg(feature = "seismic")]
-            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) => false,
+            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) | Self::Sbytes(_) | Self::FixedSbytes(..) => false,
         }
     }
 
@@ -512,7 +550,7 @@ impl Type {
             | Self::String(_)
             | Self::Bytes(_) => false,
             #[cfg(feature = "seismic")]
-            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) => false,
+            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) | Self::Sbytes(_) | Self::FixedSbytes(..) => false,
         }
     }
 

--- a/crates/syn-solidity/src/type/mod.rs
+++ b/crates/syn-solidity/src/type/mod.rs
@@ -354,10 +354,7 @@ impl Type {
                         match parse_size(s, span)? {
                             None => None,
                             Some(Some(size)) if size.get() > 32 => {
-                                return Err(Error::new(
-                                    span,
-                                    "sbytesX range is 1-32",
-                                ));
+                                return Err(Error::new(span, "sbytesX range is 1-32"));
                             }
                             Some(None) => Some(Self::Sbytes(span)),
                             Some(Some(size)) => Some(Self::FixedSbytes(span, size)),
@@ -422,7 +419,11 @@ impl Type {
         {
             let is_seismic_one_word = matches!(
                 self,
-                Self::Saddress(_) | Self::Sint(..) | Self::Suint(..) | Self::Sbool(_) | Self::FixedSbytes(..)
+                Self::Saddress(_)
+                    | Self::Sint(..)
+                    | Self::Suint(..)
+                    | Self::Sbool(_)
+                    | Self::FixedSbytes(..)
             );
             if is_seismic_one_word {
                 return true;
@@ -453,7 +454,11 @@ impl Type {
             | Self::Function(_) => false,
 
             #[cfg(feature = "seismic")]
-            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) | Self::FixedSbytes(..) => false,
+            Self::Sint(..)
+            | Self::Suint(..)
+            | Self::Saddress(..)
+            | Self::Sbool(_)
+            | Self::FixedSbytes(..) => false,
             #[cfg(feature = "seismic")]
             Self::Sbytes(_) => true,
 
@@ -529,7 +534,12 @@ impl Type {
             | Self::String(_)
             | Self::Bytes(_) => false,
             #[cfg(feature = "seismic")]
-            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) | Self::Sbytes(_) | Self::FixedSbytes(..) => false,
+            Self::Sint(..)
+            | Self::Suint(..)
+            | Self::Saddress(..)
+            | Self::Sbool(_)
+            | Self::Sbytes(_)
+            | Self::FixedSbytes(..) => false,
         }
     }
 
@@ -550,7 +560,12 @@ impl Type {
             | Self::String(_)
             | Self::Bytes(_) => false,
             #[cfg(feature = "seismic")]
-            Self::Sint(..) | Self::Suint(..) | Self::Saddress(..) | Self::Sbool(_) | Self::Sbytes(_) | Self::FixedSbytes(..) => false,
+            Self::Sint(..)
+            | Self::Suint(..)
+            | Self::Saddress(..)
+            | Self::Sbool(_)
+            | Self::Sbytes(_)
+            | Self::FixedSbytes(..) => false,
         }
     }
 


### PR DESCRIPTION
# Changes
- Added dynamic and fixed (1-32) sbyte support.
- Standardized primitive wrapper types for all sbyte and sbool.
- Added proptest/arbitrary derives to s primitives for testing.
- Integrate s types into existing tests.
- related cleanup.

# Note
PRing into `h/alloy-core-change-compilation` for use of this code alongside some other core changes for use in [provider improvements](https://github.com/SeismicSystems/seismic-alloy/pull/81) in `seismic-alloy`. 