### PR TITLE
feat!: Shielded Call Builder

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -1056,6 +1056,20 @@ fn call_builder_method(f: &ItemFunction, cx: &ExpCtxt<'_>) -> TokenStream {
             #call_name { #(#call_fields),* }
         }
     };
+
+    // If any parameter contains a shielded type, wrap in ShieldedCallBuilder
+    // to force callers through `.seismic()` before `.call()` / `.send()`.
+    #[cfg(feature = "seismic")]
+    if f.parameters.types().any(|ty| ty.has_shielded()) {
+        let alloy_sol_types = &cx.crates.sol_types;
+        return quote! {
+            #[doc = #doc]
+            pub fn #name(&self, #(#param_names1: #param_tys),*) -> #alloy_sol_types::private::ShieldedCallBuilder<alloy_contract::SolCallBuilder<&P, #call_name, N>> {
+                #alloy_sol_types::private::ShieldedCallBuilder(self.call_builder(&#call_struct))
+            }
+        };
+    }
+
     quote! {
         #[doc = #doc]
         pub fn #name(&self, #(#param_names1: #param_tys),*) -> alloy_contract::SolCallBuilder<&P, #call_name, N> {

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -86,12 +86,8 @@ pub mod private {
     #[cfg(feature = "json")]
     pub use alloy_json_abi;
 
-    /// Wrapper around a call builder for functions with shielded parameters.
-    ///
-    /// This type intentionally does not expose `.call()` or `.send()` — the
-    /// caller must invoke `.seismic()` first to obtain a builder that encrypts
-    /// calldata. This enforces at compile time that shielded functions go
-    /// through the encrypted transaction path.
+    /// Wrapper indicating that the inner call builder targets a function
+    /// with shielded types in its parameters.
     #[cfg(feature = "seismic")]
     pub struct ShieldedCallBuilder<T>(pub T);
 

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -86,6 +86,15 @@ pub mod private {
     #[cfg(feature = "json")]
     pub use alloy_json_abi;
 
+    /// Wrapper around a call builder for functions with shielded parameters.
+    ///
+    /// This type intentionally does not expose `.call()` or `.send()` — the
+    /// caller must invoke `.seismic()` first to obtain a builder that encrypts
+    /// calldata. This enforces at compile time that shielded functions go
+    /// through the encrypted transaction path.
+    #[cfg(feature = "seismic")]
+    pub struct ShieldedCallBuilder<T>(pub T);
+
     /// An ABI-encodable is any type that may be encoded via a given `SolType`.
     ///
     /// The `SolType` trait contains encoding logic for a single associated

--- a/crates/syn-solidity/src/type/mod.rs
+++ b/crates/syn-solidity/src/type/mod.rs
@@ -569,6 +569,39 @@ impl Type {
         }
     }
 
+    /// Returns whether this type contains any seismic shielded types,
+    /// recursing into arrays, tuples, and mappings.
+    #[cfg(feature = "seismic")]
+    pub fn has_shielded(&self) -> bool {
+        match self {
+            Self::Sint(..)
+            | Self::Suint(..)
+            | Self::Saddress(_)
+            | Self::Sbool(_)
+            | Self::Sbytes(_)
+            | Self::FixedSbytes(..) => true,
+
+            Self::Array(a) => a.ty.has_shielded(),
+            Self::Tuple(t) => t.types.iter().any(Self::has_shielded),
+            Self::Function(f) => {
+                f.arguments.iter().any(|arg| arg.ty.has_shielded())
+                    || f.returns
+                        .as_ref()
+                        .is_some_and(|ret| ret.returns.iter().any(|arg| arg.ty.has_shielded()))
+            }
+            Self::Mapping(m) => m.key.has_shielded() || m.value.has_shielded(),
+
+            Self::Bool(_)
+            | Self::Int(..)
+            | Self::Uint(..)
+            | Self::FixedBytes(..)
+            | Self::Address(..)
+            | Self::String(_)
+            | Self::Bytes(_)
+            | Self::Custom(_) => false,
+        }
+    }
+
     /// Returns the inner type.
     pub fn peel_arrays(&self) -> &Self {
         let mut this = self;
@@ -690,4 +723,51 @@ fn parse_size(s: &str, span: Span) -> Result<Option<Option<NonZeroU16>>> {
         },
     };
     Ok(opt)
+}
+
+#[cfg(all(test, feature = "seismic"))]
+mod tests {
+    use super::*;
+
+    fn parse_type(s: &str) -> Type {
+        syn::parse_str::<Type>(s).unwrap()
+    }
+
+    #[test]
+    fn has_shielded_primitives() {
+        // Shielded types
+        assert!(parse_type("suint256").has_shielded());
+        assert!(parse_type("sint128").has_shielded());
+        assert!(parse_type("saddress").has_shielded());
+        assert!(parse_type("sbool").has_shielded());
+        assert!(parse_type("sbytes32").has_shielded());
+        assert!(parse_type("sbytes").has_shielded());
+
+        // Non-shielded types
+        assert!(!parse_type("uint256").has_shielded());
+        assert!(!parse_type("int128").has_shielded());
+        assert!(!parse_type("address").has_shielded());
+        assert!(!parse_type("bool").has_shielded());
+        assert!(!parse_type("bytes32").has_shielded());
+        assert!(!parse_type("bytes").has_shielded());
+        assert!(!parse_type("string").has_shielded());
+    }
+
+    #[test]
+    fn has_shielded_nested() {
+        // Arrays
+        assert!(parse_type("suint256[]").has_shielded());
+        assert!(parse_type("sbytes32[3]").has_shielded());
+        assert!(!parse_type("uint256[]").has_shielded());
+
+        // Tuples
+        assert!(parse_type("(uint256, saddress)").has_shielded());
+        assert!(parse_type("(uint256, (bool, suint256))").has_shielded());
+        assert!(!parse_type("(uint256, address)").has_shielded());
+
+        // Mappings
+        assert!(parse_type("mapping(address => suint256)").has_shielded());
+        assert!(parse_type("mapping(saddress => uint256)").has_shielded());
+        assert!(!parse_type("mapping(address => uint256)").has_shielded());
+    }
 }


### PR DESCRIPTION
In the `sol!` macro, inspect functions and wrap them in the `ShieldedCallBuilder` struct if they have shielded types in their arguments.

This marker struct is used downstream in the provider in `siesmic-alloy`.