### PR TITLE
fix(flagged-storage): force explicit privacy-aware constructors

### DIFF
--- a/crates/primitives/src/storage/flagged_storage.rs
+++ b/crates/primitives/src/storage/flagged_storage.rs
@@ -4,7 +4,7 @@
 use proptest_derive::Arbitrary;
 use ruint::UintTryFrom;
 
-use crate::{FixedBytes, U256};
+use crate::U256;
 use core::fmt;
 
 /// A storage value that can be either private or public.
@@ -19,46 +19,12 @@ pub struct FlaggedStorage {
     pub is_private: bool,
 }
 
-impl<T> From<T> for FlaggedStorage
-where
-    U256: UintTryFrom<T>,
-{
-    fn from(value: T) -> Self {
-        Self { value: U256::from(value), is_private: false }
-    }
-}
-
-impl From<FlaggedStorage> for FixedBytes<32> {
-    fn from(storage: FlaggedStorage) -> FixedBytes<32> {
-        FixedBytes::<32>::from(storage.value)
-    }
-}
-
-impl Into<FlaggedStorage> for FixedBytes<32> {
-    fn into(self) -> FlaggedStorage {
-        let value: U256 = self.into();
-        FlaggedStorage::new_from_value(value)
-    }
-}
-
-impl From<FlaggedStorage> for U256 {
-    fn from(storage: FlaggedStorage) -> U256 {
-        storage.value
-    }
-}
-
-impl From<&FlaggedStorage> for U256 {
-    fn from(storage: &FlaggedStorage) -> U256 {
-        storage.value
-    }
-}
-
 impl FlaggedStorage {
     /// The default word for a flagged storage slot
     /// when no state has been set. Importantly, this slot is public by default
     pub const ZERO: Self = Self { value: U256::ZERO, is_private: false };
 
-    /// Create a private flagged storage value
+    /// Create a public flagged storage value
     pub fn public<T>(value: T) -> Self
     where
         U256: UintTryFrom<T>,
@@ -88,17 +54,6 @@ impl FlaggedStorage {
         U256: UintTryFrom<T>,
     {
         Self { value: U256::from(value), is_private }
-    }
-
-    /// Create a new FlaggedStorage value from a given value.
-    pub fn new_from_value<T>(value: T) -> Self
-    where
-        U256: UintTryFrom<T>,
-    {
-        Self {
-            value: U256::from(value),
-            is_private: false, // Default to false
-        }
     }
 
     /// Collect the values from a HashMap of FlaggedStorage values.


### PR DESCRIPTION
Fixes Veridise-905.

Veridise identified a footgun where FlaggedStorage has a lot of implicit conversions to and from U256 and FixedBytes<32>, making it easy to make errors and silently drop a privacy flag.

Claude reported that there is no bug related to this in our current codebase, but that it does make easy to do accidentally. Having impl From<FlaggedStorage> for U256 makes it trivial to silently drop privacy in a refactor. For example, any code that calls collect_value() (line 106-110) and then converts back would lose all privacy flags.

## Fix

Opted to remove both directions:
1. Remove From<FlaggedStorage> for U256 and From<FlaggedStorage> for FixedBytes<32>. Replace with an explicit .value accessor pattern. This makes the lossy conversion visible at every call site. It's a breaking change but a small one — callers already have access to the .value field.
2. Remove the primitive → FlaggedStorage impls (the generic From<T> at line 22-29 and the Into<FlaggedStorage> for FixedBytes<32> at line 37-42). Force callers to use FlaggedStorage::public(v) or FlaggedStorage::private(v) — making the privacy choice explicit at construction.

## Downstream Impact

The blast radius is significant — ~50+ call sites across 7 repos, though most are test code and easy to fix.
- Step 1 — seismic-alloy-core: Remove all 5 conversion impls
- Step 2 — Each downstream repo: Replace with explicit .value / FlaggedStorage::public() / FlaggedStorage::new(v, is_private)                                                                                                                                                            

### Seismic-trie fix

The trickiest part is seismic-trie's T: Into<FlaggedStorage> bounds on the storage_root* functions — those will need to change to accept FlaggedStorage directly.

The SEISMIC WARNING comments on lines 68, 77, 92 even acknowledge the footgun:                                                                               
> "Ensure that the storage values are flagged correctly when calling"                                                                                                       
That warning exists precisely because the T: Into<FlaggedStorage> bound allows passing a bare U256

Upstream uses concrete (B256, U256):                                                                                                           
```
// upstream alloy-trie                                                                                                                                                      
pub fn storage_root(storage: impl IntoIterator<Item = (B256, U256)>) -> B256                                                                                                
```

Seismic changed it to:                                                                                                                                                    
```
// seismic-trie                                                                                                                                                           
pub fn storage_root<T: Into<FlaggedStorage>>(storage: impl IntoIterator<Item = (B256, T)>) -> B256
```

The Into<FlaggedStorage> was a mechanical replacement for U256 that preserved the generic flexibility, but it's the wrong abstraction here — it lets callers pass a bare U256 and silently get is_private: false. The warning comments are a band-aid acknowledging this.                                                                            
                                                                                                                                                                            
The fix for seismic-trie should just be making it concrete like upstream was:                                                                                               
``` 
pub fn storage_root(storage: impl IntoIterator<Item = (B256, FlaggedStorage)>) -> B256                                                                                      
```
                                                                                                                                                                         
This forces callers to explicitly construct a FlaggedStorage with the right privacy flag before calling, which is exactly what removing the From<T> impls achieves too. Both changes reinforce each other.