### PR TITLE
ci(seismic): run on all prs

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [seismic]
   pull_request:
-    branches: [seismic]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Changing so that CI runs on PRs targetting the veridise-audit-feb-2026 branch.