### PR TITLE
fix(packed-abi-encoding): wrong fixed sizes for seismis scalar types

### DIFF
--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -1200,7 +1200,7 @@ mod seismic {
 
         const SOL_NAME: &'static str = "sbool";
         const ENCODED_SIZE: Option<usize> = Some(32);
-        const PACKED_ENCODED_SIZE: Option<usize> = Some(32);
+        const PACKED_ENCODED_SIZE: Option<usize> = Some(1);
 
         fn valid_token(token: &Self::Token<'_>) -> bool {
             utils::check_zeroes(&token.0[..31])
@@ -1269,7 +1269,7 @@ mod seismic {
 
         const SOL_NAME: &'static str = "saddress";
         const ENCODED_SIZE: Option<usize> = Some(32);
-        const PACKED_ENCODED_SIZE: Option<usize> = Some(32);
+        const PACKED_ENCODED_SIZE: Option<usize> = Some(20);
 
         #[inline]
         fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -1317,7 +1317,7 @@ mod seismic {
 
         const SOL_NAME: &'static str = IntBitCount::<BITS>::SINT_NAME;
         const ENCODED_SIZE: Option<usize> = Some(32);
-        const PACKED_ENCODED_SIZE: Option<usize> = Some(32);
+        const PACKED_ENCODED_SIZE: Option<usize> = Some(BITS / 8);
 
         #[inline]
         fn valid_token(_token: &Self::Token<'_>) -> bool {
@@ -1364,7 +1364,7 @@ mod seismic {
 
         const SOL_NAME: &'static str = IntBitCount::<BITS>::SUINT_NAME;
         const ENCODED_SIZE: Option<usize> = Some(32);
-        const PACKED_ENCODED_SIZE: Option<usize> = Some(32);
+        const PACKED_ENCODED_SIZE: Option<usize> = Some(BITS / 8);
 
         #[inline]
         fn valid_token(_token: &Self::Token<'_>) -> bool {


### PR DESCRIPTION
Fixes veridise-904.

PACKED_ENCODED_SIZE was wrongly hardcoded to 32 for all shielded types. My guess is this was done by mistake due to comparing to our compiler's behavior (see section below).

## Impact (Claude analysis)

PACKED_ENCODED_SIZE is used in two places:
1. stv_abi_packed_encoded_size() (lib.rs:108-109) — default impl returns T::PACKED_ENCODED_SIZE.unwrap(). This is used for buffer preallocation in abi_encode_packed() and for computing packed sizes of tuples/arrays. However, none of the seismic types override this method, so they'll return 32, while their stv_abi_encode_packed_to() writes fewer bytes. This means the preallocated buffer will be slightly too large (wastes memory, but doesn't corrupt data).
2. dyn-abi (DynValue::abi_packed_encoded_size) (value.rs:876-898) — this one is already correct! It hardcodes the right sizes: Sbool → 1, Saddress → 20, Sint → size/8, Suint → size/8. It doesn't read the PACKED_ENCODED_SIZE constant at all.

So the mismatch causes:
- Slight over-allocation when Vec::with_capacity uses the packed size — harmless, just wastes a few bytes
- No data corruption — the actual encoding is correct, just the size hint is wrong
- Potential issues in tuple packed size computation (data_type.rs:732-734) — if a tuple contains shielded types, the computed packed size will be too large, again causing over-allocation but not corruption

## Behavior here vs solidity compiler slot packing

Note that this is different from our [solidity compiler's packing behavior](https://github.com/SeismicSystems/seismic/blob/main/docs/language-and-vm.md#2-storage-behavior), where we cannot pack public and private state variables into a single slot since FlaggedStorage applies the `is_shielded` bool to the entire slot.

The packing behavior here is purely for people in rust doing `abi.packedEncoding()`. We could make it follow the compiler's behavior, but I can't think of a good reason why to.