### PR TITLE
feat(primitives): add back From<U256> for FlaggedStorage

### DIFF
--- a/crates/primitives/src/storage/flagged_storage.rs
+++ b/crates/primitives/src/storage/flagged_storage.rs
@@ -27,10 +27,11 @@ pub struct FlaggedStorage {
 /// The Seismic codebase never actually calls this code path (we use `seismic-alloy-genesis`
 /// which passes `FlaggedStorage` directly), but it still gets compiled as a transitive dependency.
 ///
-/// TODO(samlaf): We might implement a refactor that would allow us to get rid of our seismic-trie fork.
-/// See https://hackmd.io/@samlaf/SJcBaCBtbe). If we do implement this, then upstream alloy-genesis would
-/// call upstream alloy-trie (which takes U256 directly) and this implicit conversion would no longer be needed.
-/// I would recommend we instead force callers to use the explicit `FlaggedStorage::public/private` instead.
+/// TODO(samlaf): We might implement a refactor that would allow us to get rid of our seismic-trie
+/// fork. See https://hackmd.io/@samlaf/SJcBaCBtbe). If we do implement this, then upstream alloy-genesis would
+/// call upstream alloy-trie (which takes U256 directly) and this implicit conversion would no
+/// longer be needed. I would recommend we instead force callers to use the explicit
+/// `FlaggedStorage::public/private` instead.
 impl From<U256> for FlaggedStorage {
     fn from(value: U256) -> Self {
         Self { value, is_private: false }

--- a/crates/primitives/src/storage/flagged_storage.rs
+++ b/crates/primitives/src/storage/flagged_storage.rs
@@ -19,6 +19,24 @@ pub struct FlaggedStorage {
     pub is_private: bool,
 }
 
+/// Converts a `U256` into a **public** `FlaggedStorage`.
+///
+/// This impl exists solely because upstream `alloy-genesis` (from crates.io) calls
+/// `seismic-trie::storage_root_unhashed<T: Into<FlaggedStorage>>` with `U256` values,
+/// due to the `[patch.crates-io]` replacing `alloy-trie` with `seismic-trie`.
+/// The Seismic codebase never actually calls this code path (we use `seismic-alloy-genesis`
+/// which passes `FlaggedStorage` directly), but it still gets compiled as a transitive dependency.
+///
+/// TODO(samlaf): We might implement a refactor that would allow us to get rid of our seismic-trie fork.
+/// See https://hackmd.io/@samlaf/SJcBaCBtbe). If we do implement this, then upstream alloy-genesis would
+/// call upstream alloy-trie (which takes U256 directly) and this implicit conversion would no longer be needed.
+/// I would recommend we instead force callers to use the explicit `FlaggedStorage::public/private` instead.
+impl From<U256> for FlaggedStorage {
+    fn from(value: U256) -> Self {
+        Self { value, is_private: false }
+    }
+}
+
 impl FlaggedStorage {
     /// The default word for a flagged storage slot
     /// when no state has been set. Importantly, this slot is public by default


### PR DESCRIPTION
Removed all implicit conversion methods from FlaggedStorage in https://github.com/SeismicSystems/seismic-alloy-core/pull/63, but realized while updating seismic-alloy that we need the `From<U256> for FlaggedStorage` one because of our seismic-trie:
```
error[E0277]: the trait bound `FlaggedStorage: From<Uint<256, 4>>` is not satisfied
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/alloy-genesis-1.1.0/src/lib.rs:272:17
    |
272 | /                 alloy_trie::root::storage_root_unhashed(
273 | |                     storage
274 | |                         .into_iter()
275 | |                         .filter(|(_, value)| !value.is_zero())
276 | |                         .map(|(slot, value)| (slot, U256::from_be_bytes(*value))),
277 | |                 )
    | |_________________^ the trait `From<Uint<256, 4>>` is not implemented for `FlaggedStorage`
    |
    = note: required for `Uint<256, 4>` to implement `Into<FlaggedStorage>`
```

Annoying part is that this code is never even used because we reimplemented it for FlaggedStorage in seismic-alloy-genesis, but we still need it to compile since its a transitive dependency.

So forced to re-add this method. Thankfully this direction (U256->FlaggedStorage) is way less dangerous than the other lossy direction FlaggedStorage->U256 so think this is fine. Added a TODO saying that we can remove this method if we ever implement my plan to get rid of our seismic-trie fork.